### PR TITLE
Temporarily remove AppSignal integration

### DIFF
--- a/lib/package_builder.rb
+++ b/lib/package_builder.rb
@@ -7,7 +7,7 @@ require "aws-sdk-s3"
 
 class PackageBuilder
   class << self
-    def build!(environment = :preview)
+    def build!(environment = :staging)
       new(environment).build!
     end
 
@@ -125,7 +125,7 @@ private
 
   def create_deployments!
     create_deployment!("Webservers") do
-      notify_appsignal
+      # notify_appsignal
     end
   end
 


### PR DESCRIPTION
I've commented out AppSignal until I've decided whether it's worth configuring, and also reassigned the default environment in the build job to `staging`. 