### PR TITLE
Renamed DOMAIN environment variable

### DIFF
--- a/app/controllers/change_requests_controller.rb
+++ b/app/controllers/change_requests_controller.rb
@@ -56,7 +56,7 @@ private
   end
 
   def api_base(subdomain)
-    "#{subdomain}.#{ENV['DOMAIN'] || 'lvh.me:3000'}/api/v1"
+    "#{subdomain}.#{ENV['API_HOST'] || 'lvh.me:3000'}/api/v1"
   end
 
   def change_requests(subdomain, planning_application_id, change_request_id)


### PR DESCRIPTION
We did this as it's not immediately obvious what this variable does (it sets the base domain for the API requests).