### PR TITLE
Show previous description

### DIFF
--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -7,7 +7,7 @@
         </p>
         <div class="govuk-!-margin-top-8">
           <p class="govuk-body"><strong>Previous description</strong><br>
-            <%= @planning_application["description"] %>
+            <%= @planning_application["previous_description"] %>
           </p>
         </div>
         <div class="govuk-!-margin-top-6">


### PR DESCRIPTION
- Currently we are only displaying the planning application current description in the show page, this adds the previous description to the show page.