### PR TITLE
Show previous description

### DIFF
--- a/app/views/change_requests/show.html.erb
+++ b/app/views/change_requests/show.html.erb
@@ -7,7 +7,7 @@
         </p>
         <div class="govuk-!-margin-top-8">
           <p class="govuk-body"><strong>Previous description</strong><br>
-            <%= @planning_application["description"] %>
+            <%= @change_request["previous_description"] %>
           </p>
         </div>
         <div class="govuk-!-margin-top-6">

--- a/spec/fixtures/rejected_request.json
+++ b/spec/fixtures/rejected_request.json
@@ -14,6 +14,7 @@
       "state": "closed",
       "response_due": "2021-05-14",
       "proposed_description": "We want bird houses and a tikki bar in this!",
+      "previous_description": "We want a tikki bar in this!",
       "rejection_reason": null,
       "approved": true,
       "type": "description_change_request"

--- a/spec/fixtures/test_change_request_index.json
+++ b/spec/fixtures/test_change_request_index.json
@@ -14,6 +14,7 @@
       "state": "closed",
       "response_due": "2021-05-14",
       "proposed_description": "We want bird houses and a tikki bar in this!",
+      "previous_description": "We want a tikki bar in this!",
       "rejection_reason": null,
       "approved": true,
       "type": "description_change_request"


### PR DESCRIPTION
Up until this point, we were only displaying the current description and the proposed description. This meant when the request was completed, the former description was not kept track of. 

We now display both previous and accepted descriptions (if accepted) or just keep showing the current description if rejected.

![image](https://user-images.githubusercontent.com/9452321/118144025-e08a6580-b403-11eb-8125-a68ade376936.png)