### PR TITLE
Add cancel summary to cancelled validation requests

### DIFF
--- a/app/views/additional_document_validation_requests/show.html.erb
+++ b/app/views/additional_document_validation_requests/show.html.erb
@@ -1,11 +1,17 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <%= render "document_create_header"%>
-      <p class="govuk-body govuk-!-padding-top-6"><strong>Document uploaded:</strong><br>
-        <%= @validation_request["new_document"]["name"] %>
-      </p>
-      <%= image_tag(@validation_request["new_document"]["url"], class: "image-border") %>
+      <% if @validation_request["state"] == "cancelled" %>
+        <%= render "validation_requests/cancelled",
+          validation_request: @validation_request,
+          heading: "Cancelled request to provide a new document" %>
+      <% else %>
+        <%= render "document_create_header"%>
+        <p class="govuk-body govuk-!-padding-top-6"><strong>Document uploaded:</strong><br>
+          <%= @validation_request["new_document"]["name"] %>
+        </p>
+        <%= image_tag(@validation_request["new_document"]["url"], class: "image-border") %>
+      <% end %>
       <div class="govuk-!-margin-top-8">
         <%= link_to 'Back', validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button" %>
       </div>

--- a/app/views/description_change_validation_requests/show.html.erb
+++ b/app/views/description_change_validation_requests/show.html.erb
@@ -1,37 +1,43 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-!-padding-bottom-8">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h2 class="govuk-heading-l">Confirm changes to your application description </h2>
-        <p class="govuk-body">
-          The following changes have been made to your application's description.
-        </p>
-        <div class="govuk-!-margin-top-8">
-          <p class="govuk-body"><strong>Previous description</strong><br>
-            <%= @validation_request["previous_description"] %>
-          </p>
-        </div>
-        <div class="govuk-!-margin-top-6">
-          <p class="govuk-body"><strong>New description</strong><br>
-            <%= @validation_request["proposed_description"] %>
-          </p>
-        </div>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <% if @validation_request["approved"] == false %>
-        <strong class="govuk-tag govuk-tag--red">
-          Disagreed with suggested changes
-        </strong>
-        <p class="govuk-body govuk-!-padding-top-6"><strong>My objection and suggested wording for description: </strong><br>
-          <%= @validation_request["rejection_reason"] %>
-        </p>
+      <% if @validation_request["state"] == "cancelled" %>
+        <%= render "validation_requests/cancelled",
+          validation_request: @validation_request,
+          heading: "Cancelled request for changes to your description" %>
       <% else %>
-        <strong class="govuk-tag govuk-tag--green">
-          Agreed with suggested changes
-        </strong>
+        <h2 class="govuk-heading-l">Confirm changes to your application description </h2>
+          <p class="govuk-body">
+            The following changes have been made to your application's description.
+          </p>
+          <div class="govuk-!-margin-top-8">
+            <p class="govuk-body"><strong>Previous description</strong><br>
+              <%= @validation_request["previous_description"] %>
+            </p>
+          </div>
+          <div class="govuk-!-margin-top-6">
+            <p class="govuk-body"><strong>New description</strong><br>
+              <%= @validation_request["proposed_description"] %>
+            </p>
+          </div>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <% if @validation_request["approved"] == false %>
+          <strong class="govuk-tag govuk-tag--red">
+            Disagreed with suggested changes
+          </strong>
+          <p class="govuk-body govuk-!-padding-top-6"><strong>My objection and suggested wording for description: </strong><br>
+            <%= @validation_request["rejection_reason"] %>
+          </p>
+        <% else %>
+          <strong class="govuk-tag govuk-tag--green">
+            Agreed with suggested changes
+          </strong>
+        <% end %>
       <% end %>
     </div>
   </div>
 </div>
 
 <div class="govuk-!-padding-bottom-8">
-  <%= link_to 'Back', validation_requests_path(@validation_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-!-margin-right-1" %>
+  <%= link_to 'Back', validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-button--secondary govuk-!-margin-right-1" %>
 </div>

--- a/app/views/other_change_validation_requests/show.html.erb
+++ b/app/views/other_change_validation_requests/show.html.erb
@@ -1,32 +1,38 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-!-padding-bottom-8">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h2 class="govuk-heading-l">Respond to other validation change request </h2>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <p class="govuk-body">
-        <strong>Officer's reason for invalidating application</strong><br>
-      </p>
-      <p class="govuk-body">
-        <%= @validation_request["summary"] %>
-      </p>
-      <p class="govuk-body">
-        <strong>How you can make your application valid</strong><br>
-      </p>
-      <p class="govuk-body">
-        <%= @validation_request["suggestion"] %>
-      </p>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <p class="govuk-body">
-        <strong>My response to this request</strong><br>
-      </p>
-      <p class="govuk-body">
-        <%= @validation_request["response"] %>
-      </p>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+      <% if @validation_request["state"] == "cancelled" %>
+        <%= render "validation_requests/cancelled",
+          validation_request: @validation_request,
+          heading: "Cancelled other request to change your application" %>
+      <% else %>
+        <h2 class="govuk-heading-l">Respond to other validation change request </h2>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <p class="govuk-body">
+          <strong>Officer's reason for invalidating application</strong><br>
+        </p>
+        <p class="govuk-body">
+          <%= @validation_request["summary"] %>
+        </p>
+        <p class="govuk-body">
+          <strong>How you can make your application valid</strong><br>
+        </p>
+        <p class="govuk-body">
+          <%= @validation_request["suggestion"] %>
+        </p>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <p class="govuk-body">
+          <strong>My response to this request</strong><br>
+        </p>
+        <p class="govuk-body">
+          <%= @validation_request["response"] %>
+        </p>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+      <% end %>
     </div>
   </div>
 </div>
 
 <div class="govuk-!-padding-bottom-8">
-  <%= link_to 'Back', validation_requests_path(@validation_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-!-margin-right-1" %>
+  <%= link_to 'Back', validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-button--secondary govuk-!-margin-right-1" %>
 </div>

--- a/app/views/red_line_boundary_change_validation_requests/show.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/show.html.erb
@@ -1,37 +1,43 @@
 <div class="govuk-grid-row govuk-!-margin-top-7 govuk-!-padding-bottom-8">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h2 class="govuk-heading-l">Confirm changes to your red line boundary</h2>
-      <p class="govuk-body">
-        The following changes have been made to your application's red line boundary.
-      </p>
-      <div style="margin-top: 50px;">
-        <p class="govuk-body"><strong>Your original red line boundary</strong><br>
-        </p>
-      </div>
-      <%= render "location_map", locals: { geojson: @planning_application["boundary_geojson"] } %>
-      <div style="margin-top: 30px;">
-        <p class="govuk-body"><strong>Proposed red line boundary</strong><br>
-        </p>
-      </div>
-      <%= render "location_map", locals: { geojson: @validation_request["new_geojson"] } %>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <% if @validation_request["approved"] == false %>
-        <strong class="govuk-tag govuk-tag--red">
-          Disagreed with suggested boundary changes
-        </strong>
-        <p class="govuk-body govuk-!-padding-top-6"><strong>My reason for objecting to the boundary changes: </strong><br>
-          <%= @validation_request["rejection_reason"] %>
-        </p>
+      <% if @validation_request["state"] == "cancelled" %>
+        <%= render "validation_requests/cancelled",
+          validation_request: @validation_request,
+          heading: "Cancelled request to change your application's red line boundary" %>
       <% else %>
-        <strong class="govuk-tag govuk-tag--green">
-          Agreed with suggested boundary changes
-        </strong>
+        <h2 class="govuk-heading-l">Confirm changes to your red line boundary</h2>
+        <p class="govuk-body">
+          The following changes have been made to your application's red line boundary.
+        </p>
+        <div style="margin-top: 50px;">
+          <p class="govuk-body"><strong>Your original red line boundary</strong><br>
+          </p>
+        </div>
+        <%= render "location_map", locals: { geojson: @planning_application["boundary_geojson"] } %>
+        <div style="margin-top: 30px;">
+          <p class="govuk-body"><strong>Proposed red line boundary</strong><br>
+          </p>
+        </div>
+        <%= render "location_map", locals: { geojson: @validation_request["new_geojson"] } %>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <% if @validation_request["approved"] == false %>
+          <strong class="govuk-tag govuk-tag--red">
+            Disagreed with suggested boundary changes
+          </strong>
+          <p class="govuk-body govuk-!-padding-top-6"><strong>My reason for objecting to the boundary changes: </strong><br>
+            <%= @validation_request["rejection_reason"] %>
+          </p>
+        <% else %>
+          <strong class="govuk-tag govuk-tag--green">
+            Agreed with suggested boundary changes
+          </strong>
+        <% end %>
       <% end %>
     </div>
   </div>
 </div>
 
 <div class="govuk-!-padding-bottom-6">
-  <%= link_to 'Back', validation_requests_path(@validation_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-!-margin-right-1" %>
+  <%= link_to 'Back', validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button govuk-!-margin-right-1" %>
 </div>

--- a/app/views/replacement_document_validation_requests/show.html.erb
+++ b/app/views/replacement_document_validation_requests/show.html.erb
@@ -1,34 +1,41 @@
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h2 class="govuk-heading-l">
-        Provide a replacement document
-      </h2>
-      <p class="govuk-body">
-        The case officer has specified below why this document needs replacing.
-      </p>
-      <p class="govuk-heading-s">What you need to do:</p>
-      <ul class="govuk-list govuk-list--bullet">
-        <li>Select 'choose file' and upload a replacement file from your device</li>
-        <li>Click save to add the file</li>
-        <li>Click submit to complete this action </li>
-      </ul>
-      <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
-      <div class="govuk-!-margin-top-8">
+      <% if @validation_request["state"] == "cancelled" %>
+        <%= render "validation_requests/cancelled",
+          validation_request: @validation_request,
+          heading: "Cancelled request to provide a replacement document" %>
+      <% else %>
+        <h2 class="govuk-heading-l">
+          Provide a replacement document
+        </h2>
         <p class="govuk-body">
-          <strong> Name of file on submission:</strong><br>
-          <%= @validation_request["old_document"]["name"] %>
+          The case officer has specified below why this document needs replacing.
         </p>
-      </div>
-      <div class="govuk-!-margin-top-6">
-        <p class="govuk-body"><strong>Case officer's reason for requesting the document:</strong><br>
-          <%= @validation_request["old_document"]["invalid_document_reason"] %>
+        <p class="govuk-heading-s">What you need to do:</p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li>Select 'choose file' and upload a replacement file from your device</li>
+          <li>Click save to add the file</li>
+          <li>Click submit to complete this action </li>
+        </ul>
+        <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
+        <div class="govuk-!-margin-top-8">
+          <p class="govuk-body">
+            <strong> Name of file on submission:</strong><br>
+            <%= @validation_request["old_document"]["name"] %>
+          </p>
+        </div>
+        <div class="govuk-!-margin-top-6">
+          <p class="govuk-body"><strong>Case officer's reason for requesting the document:</strong><br>
+            <%= @validation_request["old_document"]["invalid_document_reason"] %>
+          </p>
+        </div>
+        <p class="govuk-body govuk-!-padding-top-6"><strong>Document uploaded:</strong><br>
+          <%= @validation_request["new_document"]["name"] %>
         </p>
-      </div>
-      <p class="govuk-body govuk-!-padding-top-6"><strong>Document uploaded:</strong><br>
-        <%= @validation_request["new_document"]["name"] %>
-      </p>
-      <%= image_tag(@validation_request["new_document"]["url"], class: "image-border") %>
+        <%= image_tag(@validation_request["new_document"]["url"], class: "image-border") %>
+      <% end %>
+
       <div class="govuk-!-margin-top-8">
         <%= link_to 'Back', validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "govuk-button" %>
       </div>

--- a/app/views/validation_requests/_additional_document_validation_requests.html.erb
+++ b/app/views/validation_requests/_additional_document_validation_requests.html.erb
@@ -2,7 +2,7 @@
   <h2 class="moj-task-list__section">
     <span class="moj-task-list__section-number"><%= count_total_requests(@validation_requests, "additional_document_validation_requests") %> </span>Provide new or missing documents
   </h2>
-  <ul class="moj-task-list__items" id="validation-section">
+  <ul class="moj-task-list__items" id="additional-document-validation-requests">
     <% @validation_requests["data"]["additional_document_validation_requests"].each do |change_request| %>
       <li class="moj-task-list__item">
         <% if change_request["state"] == "open" %>
@@ -10,15 +10,8 @@
         <% else %>
           <%= link_to "New document", additional_document_validation_request_path(change_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "moj-task-list__task-name" %>
         <% end %>
-        <% if change_request["state"] == 'open' %>
-          <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
-            Not started
-          </strong>
-        <% else %>
-          <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
-            Complete
-          </strong>
-        <% end %>
+
+        <%= render "validation_requests/change_request_state", change_request: change_request %>
       </li>
     <% end %>
   </ul>

--- a/app/views/validation_requests/_cancelled.html.erb
+++ b/app/views/validation_requests/_cancelled.html.erb
@@ -1,0 +1,13 @@
+<h1 class="govuk-heading-xl"><%= heading %></h1>
+<p class="govuk-body">This request has been cancelled. You do not have to take any further actions.</p>
+<p class="govuk-body">
+  <strong>The officer gave the following reason for cancelling this request:</strong>
+</p>
+<div class="govuk-inset-text">
+  <p class="govuk-body">
+    <%= validation_request["cancel_reason"] %>
+  </p>
+  <p class="govuk-body">
+    <%= validation_request["cancelled_at"].to_time.to_formatted_s(:day_month_year) %>
+  </p>
+</div>

--- a/app/views/validation_requests/_change_request_state.html.erb
+++ b/app/views/validation_requests/_change_request_state.html.erb
@@ -1,0 +1,13 @@
+<% if change_request["state"] == 'open' %>
+  <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
+    Not started
+  </strong>
+<% elsif change_request["state"] == 'cancelled' %>
+  <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
+    Cancelled
+  </strong>
+<% else %>
+  <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
+    Complete
+  </strong>
+<% end %>

--- a/app/views/validation_requests/_description_change_validation_requests.html.erb
+++ b/app/views/validation_requests/_description_change_validation_requests.html.erb
@@ -2,7 +2,7 @@
   <h2 class="moj-task-list__section">
     <span class="moj-task-list__section-number">1. </span>Confirm changes to your application description
   </h2>
-  <ul class="moj-task-list__items" id="validation-section">
+  <ul class="moj-task-list__items" id="description-change-validation-requests">
     <% @validation_requests["data"]["description_change_validation_requests"].each do |change_request| %>
       <li class="moj-task-list__item">
         <% if change_request["state"] == "open" %>
@@ -10,15 +10,8 @@
         <% else %>
           <%= link_to "Description", description_change_validation_request_path(change_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "moj-task-list__task-name" %>
         <% end %>
-        <% if change_request["state"] == 'open' %>
-          <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
-            Not started
-          </strong>
-        <% else %>
-          <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
-            Complete
-          </strong>
-        <% end %>
+
+        <%= render "validation_requests/change_request_state", change_request: change_request %>
       </li>
     <% end %>
   </ul>

--- a/app/views/validation_requests/_other_change_validation_requests.html.erb
+++ b/app/views/validation_requests/_other_change_validation_requests.html.erb
@@ -2,7 +2,7 @@
   <h2 class="moj-task-list__section">
     <span class="moj-task-list__section-number"><%= count_total_requests(@validation_requests, "other_change_validation_requests")   %></span>Respond to other request
   </h2>
-  <ul class="moj-task-list__items" id="validation-section">
+  <ul class="moj-task-list__items" id="other-change-validation-requests">
     <% @validation_requests["data"]["other_change_validation_requests"].each do |change_request| %>
       <li class="moj-task-list__item">
         <% if change_request["state"] == "open" %>
@@ -10,15 +10,8 @@
         <% else %>
           <%= link_to "Other request", other_change_validation_request_path(change_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "moj-task-list__task-name" %>
         <% end %>
-        <% if change_request["state"] == 'open' %>
-          <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
-            Not started
-          </strong>
-        <% else %>
-          <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
-            Complete
-          </strong>
-        <% end %>
+
+        <%= render "validation_requests/change_request_state", change_request: change_request %>
       </li>
     <% end %>
   </ul>

--- a/app/views/validation_requests/_red_line_boundary_change_validation_requests.html.erb
+++ b/app/views/validation_requests/_red_line_boundary_change_validation_requests.html.erb
@@ -2,7 +2,7 @@
   <h2 class="moj-task-list__section">
     <span class="moj-task-list__section-number"><%= count_total_requests(@validation_requests, "red_line_boundary_change_validation_requests") %></span>Confirm changes to your application's red line boundary
   </h2>
-  <ul class="moj-task-list__items" id="validation-section">
+  <ul class="moj-task-list__items" id="red-line-boundary-change-validation-requests">
     <% @validation_requests["data"]["red_line_boundary_change_validation_requests"].each do |change_request| %>
       <li class="moj-task-list__item">
         <% if change_request["state"] == "open" %>
@@ -10,15 +10,8 @@
         <% else %>
           <%= link_to "Red Line Boundary", red_line_boundary_change_validation_request_path(change_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "moj-task-list__task-name" %>
         <% end %>
-        <% if change_request["state"] == 'open' %>
-          <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
-            Not started
-          </strong>
-        <% else %>
-          <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
-            Complete
-          </strong>
-        <% end %>
+
+        <%= render "validation_requests/change_request_state", change_request: change_request %>
       </li>
     <% end %>
   </ul>

--- a/app/views/validation_requests/_replacement_document_validation_requests.html.erb
+++ b/app/views/validation_requests/_replacement_document_validation_requests.html.erb
@@ -2,7 +2,7 @@
   <h2 class="moj-task-list__section">
     <span class="moj-task-list__section-number"><%= count_total_requests(@validation_requests, "replacement_document_validation_requests")   %></span>Provide replacement documents
   </h2>
-  <ul class="moj-task-list__items" id="validation-section">
+  <ul class="moj-task-list__items" id="replacement-document-validation-requests">
     <% @validation_requests["data"]["replacement_document_validation_requests"].each do |change_request| %>
       <li class="moj-task-list__item">
         <% if change_request["state"] == "open" %>
@@ -10,15 +10,8 @@
         <% else %>
           <%= link_to "#{change_request["old_document"]["name"]}", replacement_document_validation_request_path(change_request["id"], planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"]), class: "moj-task-list__task-name" %>
         <% end %>
-        <% if change_request["state"] == 'open' %>
-          <strong class="govuk-tag govuk-tag--grey" style="float: right;" id="eligibility-status">
-            Not started
-          </strong>
-        <% else %>
-          <strong class="govuk-tag app-task-list__tag" style="float: right;" id="eligibility-status">
-            Complete
-          </strong>
-        <% end %>
+
+        <%= render "validation_requests/change_request_state", change_request: change_request %>
       </li>
     <% end %>
   </ul>

--- a/config/initializers/date_formatter.rb
+++ b/config/initializers/date_formatter.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Time::DATE_FORMATS[:day_month_year] = Date::DATE_FORMATS[:day_month_year] = "%-d %B %Y"

--- a/spec/fixtures/cancelled_validation_requests.json
+++ b/spec/fixtures/cancelled_validation_requests.json
@@ -1,0 +1,76 @@
+{
+  "data": {
+    "description_change_validation_requests": [
+      {
+        "id": 18,
+        "state": "cancelled",
+        "response_due": "2021-05-14",
+        "proposed_description": "This is a better description",
+        "rejection_reason": null,
+        "approved": null,
+        "cancel_reason": "My mistake",
+        "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+        "type": "description_validation_change_request"
+      }
+    ],
+    "red_line_boundary_change_validation_requests": [
+      {
+        "id": 10,
+        "state": "cancelled",
+        "response_due": "2021-05-14",
+        "new_geojson": "",
+        "reason": null,
+        "approved": null,
+        "cancel_reason": "My mistake",
+        "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+        "type": "red_line_boundary_change_validation_request"
+      }
+    ],
+    "replacement_document_validation_requests": [
+      {
+        "id": 8,
+        "state": "cancelled",
+        "response_due": "2021-06-10",
+        "days_until_response_due": 15,
+        "old_document": {
+          "name": "20210512_162911.jpg",
+          "invalid_document_reason": "Its a chicken coop not a floor plan."
+        },
+        "cancel_reason": "My mistake",
+        "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+        "type": "replacement_document_validation_request"
+      }
+    ],
+    "additional_document_validation_requests": [
+      {
+        "id": 4,
+        "state": "cancelled",
+        "response_due": "2021-06-17",
+        "days_until_response_due": 15,
+        "document_request_type": "Floor plan",
+        "document_request_reason": "No floor plan",
+        "new_document": {
+          "name": "proposed-floorplan.png",
+          "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan.png"
+        },
+        "cancel_reason": "My mistake",
+        "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+        "type": "additional_document_validation_request"
+      }
+    ],
+    "other_change_validation_requests": [
+      {
+        "id": 4,
+        "state": "cancelled",
+        "response_due": "2021-06-17",
+        "days_until_response_due": 15,
+        "summary": "The wrong fee has been paid",
+        "suggestion": "You need to pay an extra £100",
+        "response": "I disagree with the extra fee",
+        "cancel_reason": "My mistake",
+        "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+        "type": "other_change_request"
+      }
+    ]
+  }
+}

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -25,4 +25,10 @@ module ApiSpecHelper
     .with(headers: headers)
     .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
   end
+
+  def stub_cancelled_change_requests
+    stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
+    .with(headers: headers)
+    .to_return(status: 200, body: file_fixture("cancelled_validation_requests.json").read, headers: {})
+  end
 end

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -47,4 +47,18 @@ RSpec.describe "Document create requests", type: :system do
     expect(page).to have_content "No floor plan"
     expect(page).to have_content "proposed-floorplan.png"
   end
+
+  it "displays a cancellation summary for a cancelled validation request" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/additional_document_validation_requests/4?change_access_id=345443543&planning_application_id=28"
+
+    expect(page).to have_content "Cancelled request to provide a new document"
+    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+    expect(page).to have_content "My mistake"
+    expect(page).to have_content "20 October 2021"
+    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+  end
 end

--- a/spec/system/description_change_request_spec.rb
+++ b/spec/system/description_change_request_spec.rb
@@ -84,4 +84,18 @@ RSpec.describe "Description change requests", type: :system do
     expect(page).to have_content("My objection and suggested wording for description:")
     expect(page).to have_content("I wish to build a roman theatre.")
   end
+
+  it "displays a cancellation summary for a cancelled validation request" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/description_change_validation_requests/18?change_access_id=345443543&planning_application_id=28"
+
+    expect(page).to have_content "Cancelled request for changes to your description"
+    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+    expect(page).to have_content "My mistake"
+    expect(page).to have_content "20 October 2021"
+    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+  end
 end

--- a/spec/system/other_change_validation_request_spec.rb
+++ b/spec/system/other_change_validation_request_spec.rb
@@ -44,4 +44,18 @@ RSpec.describe "Other change requests", type: :system do
     click_button "Submit"
     expect(page).to have_content "Please enter your response to the planning officer's question."
   end
+
+  it "displays a cancellation summary for a cancelled validation request" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/other_change_validation_requests/4?change_access_id=345443543&planning_application_id=28"
+
+    expect(page).to have_content "Cancelled other request to change your application"
+    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+    expect(page).to have_content "My mistake"
+    expect(page).to have_content "20 October 2021"
+    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+  end
 end

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -84,4 +84,18 @@ RSpec.describe "Description change requests", type: :system do
     expect(page).to have_content("My reason for objecting to the boundary changes:")
     expect(page).to have_content("I do not agree with this boundary")
   end
+
+  it "displays a cancellation summary for a cancelled validation request" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
+
+    expect(page).to have_content "Cancelled request to change your application's red line boundary"
+    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+    expect(page).to have_content "My mistake"
+    expect(page).to have_content "20 October 2021"
+    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+  end
 end

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -48,4 +48,18 @@ RSpec.describe "Document change requests", type: :system do
     expect(page).to have_content "Document uploaded:"
     expect(page).to have_content "max-baskakov-catunsplash.jpg"
   end
+
+  it "displays a cancellation summary for a cancelled validation request" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28"
+
+    expect(page).to have_content "Cancelled request to provide a replacement document"
+    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+    expect(page).to have_content "My mistake"
+    expect(page).to have_content "20 October 2021"
+    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+  end
 end

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -56,4 +56,36 @@ RSpec.describe "Change requests", type: :system do
 
     expect(page).to have_content("This is a better description")
   end
+
+  it "allows the user to see cancelled change requests associated with their application" do
+    stub_cancelled_change_requests
+    stub_successful_get_planning_application
+
+    visit "/validation_requests?planning_application_id=28&change_access_id=345443543"
+
+    within("#description-change-validation-requests") do
+      expect(page).to have_link("Description", href: "/description_change_validation_requests/18?change_access_id=345443543&planning_application_id=28")
+      expect(page).to have_content("Cancelled")
+    end
+
+    within("#other-change-validation-requests") do
+      expect(page).to have_link("Other request", href: "/other_change_validation_requests/4?change_access_id=345443543&planning_application_id=28")
+      expect(page).to have_content("Cancelled")
+    end
+
+    within("#red-line-boundary-change-validation-requests") do
+      expect(page).to have_link("Red Line Boundary", href: "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28")
+      expect(page).to have_content("Cancelled")
+    end
+
+    within("#replacement-document-validation-requests") do
+      expect(page).to have_link("20210512_162911.jpg", href: "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28")
+      expect(page).to have_content("Cancelled")
+    end
+
+    within("#additional-document-validation-requests") do
+      expect(page).to have_link("New document", href: "/additional_document_validation_requests/4?change_access_id=345443543&planning_application_id=28")
+      expect(page).to have_content("Cancelled")
+    end
+  end
 end


### PR DESCRIPTION
- Add new "Cancelled" state on validation requests index page
- Add cancellation summary for each of the requests

Associated with https://github.com/unboxed/bops/pull/443

![Screenshot 2021-10-21 at 15 42 08](https://user-images.githubusercontent.com/34001723/138301443-e437face-8a2b-4846-9b4a-64abb86d7589.png)
![Screenshot 2021-10-21 at 15 42 23](https://user-images.githubusercontent.com/34001723/138301456-8fdb2850-bf80-4296-aadf-3bc04eb61a04.png)