### PR TITLE
Use show endpoints from BOPS api

### DIFF
--- a/app/controllers/concerns/api/error_handler.rb
+++ b/app/controllers/concerns/api/error_handler.rb
@@ -17,7 +17,8 @@ module Api::ErrorHandler
     def format_error(error)
       error_hash = instance_eval(error.message)
 
-      message = error_hash[:response]["message"]
+      response = error_hash[:response]
+      message = response["message"] || response
       status = error_hash[:status].to_s || API_ERROR.to_s
       http_method = error_hash[:http_method].to_s
 

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -1,5 +1,5 @@
 class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsController
-  before_action :set_validation_request
+  before_action :set_validation_request, :set_planning_application
 
   def show
     respond_to do |format|

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -1,7 +1,7 @@
 class ValidationRequestsController < ApplicationController
   include Api::ErrorHandler
 
-  before_action :set_planning_application, :set_validation_requests
+  before_action :set_planning_application, :set_validation_requests, only: :index
 
   def index
     respond_to do |format|
@@ -20,13 +20,13 @@ private
   end
 
   def set_validation_request
-    # FIXME: - This is a seriously inefficient way of grabbing the validation request record.
-    # when we add the show endpoints for each validation request this can be changed
-    @validation_request = @validation_requests["data"][controller_name.pluralize.to_s].find { |obj| obj["id"] == params["id"].to_i }
+    @validation_request = validation_request_model_klass.find(
+      params[:id], params[:planning_application_id], params[:change_access_id]
+    )
   end
 
   def build_validation_request(attributes = {})
-    "Bops::#{controller_name.classify}".constantize.new(attributes).tap do |attribute|
+    validation_request_model_klass.new(attributes).tap do |attribute|
       attribute.id = params[:id]
       attribute.planning_application_id = params[:planning_application_id]
       attribute.change_access_id = params[:change_access_id]
@@ -63,5 +63,9 @@ private
   def error_message(validation_request)
     errors = validation_request.errors
     errors.any? ? errors.full_messages.to_sentence : "Oops something went wrong. Please contact support."
+  end
+
+  def validation_request_model_klass
+    "Bops::#{controller_name.classify}".constantize
   end
 end

--- a/app/models/bops/additional_document_validation_request.rb
+++ b/app/models/bops/additional_document_validation_request.rb
@@ -9,17 +9,13 @@ module Bops
     validates :file, presence: true
 
     class << self
+      def find(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_additional_document_validation_request(id, planning_application_id, change_access_id)
+      end
+
       def add_document(id, planning_application_id, change_access_id, file)
         Apis::Bops::Client.patch_additional_document(id, planning_application_id, change_access_id, file)
       end
-
-      ## To implement (when we add a show /:id endpoint)
-      # def find(id, planning_application_id)
-      # end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
 
     def update

--- a/app/models/bops/description_change_validation_request.rb
+++ b/app/models/bops/description_change_validation_request.rb
@@ -10,6 +10,10 @@ module Bops
     validates :rejection_reason, presence: true, if: :not_approved?
 
     class << self
+      def find(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_description_change_validation_request(id, planning_application_id, change_access_id)
+      end
+
       def approve(id, planning_application_id, change_access_id)
         Apis::Bops::Client.patch_approved_description_change(id, planning_application_id, change_access_id)
       end
@@ -17,14 +21,6 @@ module Bops
       def reject(id, planning_application_id, change_access_id, rejection_reason)
         Apis::Bops::Client.patch_rejected_description_change(id, planning_application_id, change_access_id, rejection_reason)
       end
-
-      ## To implement (when we add a show /:id endpoint)
-      # def find(id, planning_application_id)
-      # end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
 
     def update

--- a/app/models/bops/other_change_validation_request.rb
+++ b/app/models/bops/other_change_validation_request.rb
@@ -9,17 +9,13 @@ module Bops
     validates :response, presence: true
 
     class << self
+      def find(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_other_change_validation_request(id, planning_application_id, change_access_id)
+      end
+
       def respond(id, planning_application_id, change_access_id, response)
         Apis::Bops::Client.patch_response_other_change_request(id, planning_application_id, change_access_id, response)
       end
-
-      ## To implement (when we add a show /:id endpoint)
-      # def find(id, planning_application_id)
-      # end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
 
     def update

--- a/app/models/bops/planning_application.rb
+++ b/app/models/bops/planning_application.rb
@@ -6,10 +6,6 @@ module Bops
       def find(planning_application_id)
         Apis::Bops::Client.get_planning_application(planning_application_id)
       end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
   end
 end

--- a/app/models/bops/red_line_boundary_change_validation_request.rb
+++ b/app/models/bops/red_line_boundary_change_validation_request.rb
@@ -10,6 +10,10 @@ module Bops
     validates :rejection_reason, presence: true, if: :not_approved?
 
     class << self
+      def find(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_red_line_boundary_change_validation_request(id, planning_application_id, change_access_id)
+      end
+
       def approve(id, planning_application_id, change_access_id)
         Apis::Bops::Client.patch_approved_red_line_boundary_change(id, planning_application_id, change_access_id)
       end
@@ -17,14 +21,6 @@ module Bops
       def reject(id, planning_application_id, change_access_id, rejection_reason)
         Apis::Bops::Client.patch_rejected_red_line_boundary_change(id, planning_application_id, change_access_id, rejection_reason)
       end
-
-      ## To implement (when we add a show /:id endpoint)
-      # def find(id, planning_application_id)
-      # end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
 
     def update

--- a/app/models/bops/replacement_document_validation_request.rb
+++ b/app/models/bops/replacement_document_validation_request.rb
@@ -9,17 +9,13 @@ module Bops
     validates :file, presence: true
 
     class << self
+      def find(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_replacement_document_validation_request(id, planning_application_id, change_access_id)
+      end
+
       def replace_document(id, planning_application_id, change_access_id, file)
         Apis::Bops::Client.patch_replacement_document(id, planning_application_id, change_access_id, file)
       end
-
-      ## To implement (when we add a show /:id endpoint)
-      # def find(id, planning_application_id)
-      # end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
 
     def update

--- a/app/models/bops/validation_request.rb
+++ b/app/models/bops/validation_request.rb
@@ -6,10 +6,6 @@ module Bops
       def find_all(planning_application_id, change_access_id)
         Apis::Bops::Client.get_validation_requests(planning_application_id, change_access_id)
       end
-
-      ## To implement (we just want to build the minimum response required by the view)
-      # def build(attributes)
-      # end
     end
   end
 end

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -4,6 +4,15 @@ module Apis
   module Bops
     class Client
       class << self
+        # Planning application
+        def get_planning_application(planning_application_id)
+          request(
+            http_method: :get,
+            endpoint: planning_application_id.to_s,
+          )
+        end
+
+        # Validation requests
         def get_validation_requests(planning_application_id, change_access_id)
           request(
             http_method: :get,
@@ -11,10 +20,11 @@ module Apis
           )
         end
 
-        def get_planning_application(planning_application_id)
+        # Description change validation requests
+        def get_description_change_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: planning_application_id.to_s,
+            endpoint: "#{planning_application_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
           )
         end
 
@@ -43,6 +53,14 @@ module Apis
           )
         end
 
+        # Other change validation requests
+        def get_other_change_validation_request(id, planning_application_id, change_access_id)
+          request(
+            http_method: :get,
+            endpoint: "#{planning_application_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+          )
+        end
+
         def patch_response_other_change_request(id, planning_application_id, change_access_id, response)
           request(
             http_method: :patch,
@@ -52,6 +70,14 @@ module Apis
                 "response": response,
               },
             }.to_json,
+          )
+        end
+
+        # Red line boundary change validation requests
+        def get_red_line_boundary_change_validation_request(id, planning_application_id, change_access_id)
+          request(
+            http_method: :get,
+            endpoint: "#{planning_application_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
           )
         end
 
@@ -80,6 +106,14 @@ module Apis
           )
         end
 
+        # Additional document validation requests
+        def get_additional_document_validation_request(id, planning_application_id, change_access_id)
+          request(
+            http_method: :get,
+            endpoint: "#{planning_application_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+          )
+        end
+
         def patch_additional_document(id, planning_application_id, change_access_id, file)
           request(
             http_method: :patch,
@@ -88,6 +122,14 @@ module Apis
               "file": file,
             },
             upload_file: true,
+          )
+        end
+
+        # Replacement document validation requests
+        def get_replacement_document_validation_request(id, planning_application_id, change_access_id)
+          request(
+            http_method: :get,
+            endpoint: "#{planning_application_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
           )
         end
 

--- a/app/views/description_change_validation_requests/edit.html.erb
+++ b/app/views/description_change_validation_requests/edit.html.erb
@@ -14,7 +14,7 @@
           <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
           <div style="margin-top: 50px;">
             <p class="govuk-body"><strong>Previous description</strong><br>
-              <%= @planning_application["description"] %>
+              <%= @validation_request["previous_description"] %>
             </p>
           </div>
           <div style="margin-top: 30px;">

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -1,4 +1,6 @@
 module ApiSpecHelper
+  API_BASE_URL = "https://default.bops-care.link/api/v1/planning_applications".freeze
+
   def headers
     {
       "Accept" => "*/*",

--- a/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_get_additional_document_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+      )
+      .to_return(
+        body: JSON.generate(response_body),
+        status: status,
+      )
+    end
+
+    def stub_patch_additional_document_validation_request(id:, planning_id:, change_access_id:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .to_return(
+        body: "",
+        status: status,
+      )
+    end
+  end
+
+  config.include helpers, type: :system
+end

--- a/spec/support/bops_api_request_stubs/description_change_validation_requests.rb
+++ b/spec/support/bops_api_request_stubs/description_change_validation_requests.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_get_description_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+      )
+      .to_return(
+        body: JSON.generate(response_body),
+        status: status,
+      )
+    end
+
+    def stub_patch_approved_description_change_validation_request(id:, planning_id:, change_access_id:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+        body: { data: { approved: true } }.to_json,
+      )
+      .to_return(
+        body: "{}",
+        status: status,
+      )
+    end
+
+    def stub_patch_rejected_description_change_validation_request(id:, planning_id:, change_access_id:, rejection_reason:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+        body: { data: { approved: false, rejection_reason: rejection_reason } }.to_json,
+      )
+      .to_return(
+        body: "{}",
+        status: status,
+      )
+    end
+  end
+
+  config.include helpers, type: :system
+end

--- a/spec/support/bops_api_request_stubs/other_change_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/other_change_validation_request.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_get_other_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+      )
+      .to_return(
+        body: JSON.generate(response_body),
+        status: status,
+      )
+    end
+
+    def stub_patch_other_change_validation_request(id:, planning_id:, change_access_id:, response:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+        body: { data: { response: response } }.to_json,
+      )
+      .to_return(
+        body: "{}",
+        status: status,
+      )
+    end
+  end
+
+  config.include helpers, type: :system
+end

--- a/spec/support/bops_api_request_stubs/red_line_boundary_change_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/red_line_boundary_change_validation_request.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_get_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+      )
+      .to_return(
+        body: JSON.generate(response_body),
+        status: status,
+      )
+    end
+
+    def stub_patch_approved_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+        body: { data: { approved: true } }.to_json,
+      )
+      .to_return(
+        body: "{}",
+        status: status,
+      )
+    end
+
+    def stub_patch_rejected_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, rejection_reason:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+        body: { data: { approved: false, rejection_reason: rejection_reason } }.to_json,
+      )
+      .to_return(
+        body: "{}",
+        status: status,
+      )
+    end
+  end
+
+  config.include helpers, type: :system
+end

--- a/spec/support/bops_api_request_stubs/replacement_document_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/replacement_document_validation_request.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+RSpec.configure do |config|
+  helpers = Module.new do
+    def stub_get_replacement_document_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
+      stub_request(
+        :get,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .with(
+        headers: headers,
+      )
+      .to_return(
+        body: JSON.generate(response_body),
+        status: status,
+      )
+    end
+
+    def stub_patch_replacement_document_validation_request(id:, planning_id:, change_access_id:, status:)
+      stub_request(
+        :patch,
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+      )
+      .to_return(
+        body: "",
+        status: status,
+      )
+    end
+  end
+
+  config.include helpers, type: :system
+end

--- a/spec/system/description_change_request_spec.rb
+++ b/spec/system/description_change_request_spec.rb
@@ -4,126 +4,168 @@ RSpec.describe "Description change requests", type: :system do
   before do
     ENV["API_BEARER"] = "123"
     ENV["PROTOCOL"] = "https"
+
+    stub_successful_get_planning_application
+    stub_get_description_change_validation_request(
+      id: 22,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 22,
+          "state": "open",
+        },
+      status: 200,
+    )
   end
 
-  it "allows the user to accept a change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is open" do
+    context "accepting change request" do
+      before do
+        stub_patch_approved_description_change_validation_request(
+          id: 22,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          status: 200,
+        )
+      end
 
-    visit "/description_change_validation_requests/18/edit?change_access_id=345443543&planning_application_id=28"
+      it "allows the user to accept a change request" do
+        visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
 
-    choose "Yes, I agree with the changes made"
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/description_change_validation_requests/18?change_access_id=345443543")
-    .with(
-      body: { data: { approved: true } }.to_json,
-      headers: headers,
-    ).to_return(status: 200, body: "{}")
+        choose "Yes, I agree with the changes made"
 
-    click_button "Submit"
+        stub_successful_get_change_requests
+        click_button "Submit"
 
-    expect(change_request_patch_request).to have_been_requested
-    expect(page).to have_content("Your response was updated successfully")
-  end
-
-  it "allows the user to reject a change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content("Do you agree with the changes made to your application description?")
-    choose "No, I disagree with the changes made"
-    fill_in "Please indicate why you disagree with the changes and provide your suggested wording for the description.", with: "I wish to build a roman theatre"
-
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/description_change_validation_requests/22?change_access_id=345443543")
-    .with(
-      body: { data: { approved: false, rejection_reason: "I wish to build a roman theatre" } }.to_json,
-      headers: headers,
-    ).to_return(status: 200, body: "{}")
-
-    click_button "Submit"
-
-    expect(change_request_patch_request).to have_been_requested
-    stub_successful_get_planning_application
-
-    stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-    .with(headers: headers)
-    .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
-  end
-
-  it "display an error if an option has not been selected" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
-
-    click_button "Submit"
-    within(".govuk-error-summary") do
-      expect(page).to have_content "Please select an option"
+        expect(page).to have_content("Your response was updated successfully")
+      end
     end
-  end
 
-  it "does not allow the user to reject a change request without filling in a rejection reason" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+    context "rejecting change request" do
+      before do
+        stub_patch_rejected_description_change_validation_request(
+          id: 22,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          rejection_reason: "I wish to build a roman theatre",
+          status: 200,
+        )
+      end
 
-    visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
+      it "allows the user to reject a change request" do
+        visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
 
-    choose "No, I disagree with the changes made"
+        expect(page).to have_content("Do you agree with the changes made to your application description?")
+        choose "No, I disagree with the changes made"
+        fill_in "Please indicate why you disagree with the changes and provide your suggested wording for the description.", with: "I wish to build a roman theatre"
 
-    click_button "Submit"
-    within(".govuk-error-summary") do
-      expect(page).to have_content "Please fill in the reason for disagreeing with the suggested change."
+        stub_successful_get_change_requests
+        click_button "Submit"
+
+        expect(page).to have_content("Your response was updated successfully")
+      end
+    end
+
+    context "when there are validation errors" do
+      it "display an error if an option has not been selected" do
+        visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
+
+        click_button "Submit"
+        within(".govuk-error-summary") do
+          expect(page).to have_content "Please select an option"
+        end
+      end
+
+      it "does not allow the user to reject a change request without filling in a rejection reason" do
+        visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
+
+        choose "No, I disagree with the changes made"
+
+        click_button "Submit"
+        within(".govuk-error-summary") do
+          expect(page).to have_content "Please fill in the reason for disagreeing with the suggested change."
+        end
+      end
     end
   end
 
   it "displays the correct label for an accepted description change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+    stub_get_description_change_validation_request(
+      id: 22,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 22,
+          "state": "closed",
+          "approved": true,
 
-    visit "/description_change_validation_requests/19?change_access_id=345443543&planning_application_id=28"
+        },
+      status: 200,
+    )
 
+    visit "/description_change_validation_requests/22?change_access_id=345443543&planning_application_id=28"
     expect(page).to have_content("Agreed with suggested changes")
   end
 
-  it "displays the correct label for a rejected description change request" do
-    stub_successful_get_planning_application
-    stub_rejected_patch_with_reason
+  context "when state is closed" do
+    before do
+      stub_get_description_change_validation_request(
+        id: 22,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 22,
+            "state": "closed",
+            "proposed_description": "I wish to build a roman theatre.",
+            "approved": false,
+          },
+        status: 200,
+      )
+    end
 
-    visit "/description_change_validation_requests/22?change_access_id=345443543&planning_application_id=28"
+    it "displays the correct label for a rejected description change request" do
+      visit "/description_change_validation_requests/22?change_access_id=345443543&planning_application_id=28"
 
-    expect(page).to have_content("Disagreed with suggested changes")
-    expect(page).to have_content("My objection and suggested wording for description:")
-    expect(page).to have_content("I wish to build a roman theatre.")
+      expect(page).to have_content("Disagreed with suggested changes")
+      expect(page).to have_content("My objection and suggested wording for description:")
+      expect(page).to have_content("I wish to build a roman theatre.")
+    end
+
+    it "can't view edit action if state is closed" do
+      visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
+    end
   end
 
-  it "can't view show action if state is open" do
-    stub_successful_get_planning_application
-    stub_successful_get_change_requests
+  context "when state is cancelled" do
+    before do
+      stub_get_description_change_validation_request(
+        id: 22,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 22,
+            "state": "cancelled",
+            "cancel_reason": "My mistake",
+            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+          },
+        status: 200,
+      )
+    end
 
-    visit "/description_change_validation_requests/18?change_access_id=345443543&planning_application_id=28"
-    expect(page).to have_content("Not Found")
-  end
+    it "displays a cancellation summary for a cancelled validation request" do
+      visit "/description_change_validation_requests/22?change_access_id=345443543&planning_application_id=28"
 
-  it "can't view edit action if state is closed" do
-    stub_successful_get_planning_application
-    stub_successful_get_change_requests
-
-    visit "/description_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
-    expect(page).to have_content("Not Found")
-  end
-
-  it "displays a cancellation summary for a cancelled validation request" do
-    stub_cancelled_change_requests
-    stub_successful_get_planning_application
-
-    visit "/description_change_validation_requests/18?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content "Cancelled request for changes to your description"
-    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
-    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
-    expect(page).to have_content "My mistake"
-    expect(page).to have_content "20 October 2021"
-    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content "Cancelled request for changes to your description"
+      expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+      expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+      expect(page).to have_content "My mistake"
+      expect(page).to have_content "20 October 2021"
+      expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+    end
   end
 end

--- a/spec/system/other_change_validation_request_spec.rb
+++ b/spec/system/other_change_validation_request_spec.rb
@@ -4,60 +4,117 @@ RSpec.describe "Other change requests", type: :system do
   before do
     ENV["API_BEARER"] = "123"
     ENV["PROTOCOL"] = "https"
+
+    stub_successful_get_planning_application
+    stub_get_other_change_validation_request(
+      id: 19,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 19,
+          "state": "open",
+          "summary": "You applied for the wrong sort of certificate",
+          "suggestion": "Please confirm you want a Lawful Development certificate",
+        },
+      status: 200,
+    )
   end
 
-  it "allows the user to provide a response" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is open" do
+    before do
+      stub_patch_other_change_validation_request(
+        id: 19,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response: "Agreed",
+        status: 200,
+      )
+    end
 
-    visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
+    it "allows the user to provide a response" do
+      visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
 
-    expect(page).to have_content("You applied for the wrong sort of certificate")
-    expect(page).to have_content("Please confirm you want a Lawful Development certificate")
+      expect(page).to have_content("You applied for the wrong sort of certificate")
+      expect(page).to have_content("Please confirm you want a Lawful Development certificate")
 
-    fill_in "Respond to this request", with: "Agreed"
+      fill_in "Respond to this request", with: "Agreed"
 
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/other_change_validation_requests/19?change_access_id=345443543")
-        .with(
-          body: { data: { response: "Agreed" } }.to_json,
-          headers: headers,
-        ).to_return(status: 200, body: "{}")
+      stub_successful_get_change_requests
+      click_button "Submit"
 
-    click_button "Submit"
+      expect(page).to have_content("Your response was updated successfully")
+    end
 
-    expect(change_request_patch_request).to have_been_requested
-    expect(page).to have_content("Your response was updated successfully")
+    it "can't view show action" do
+      visit "/other_change_validation_requests/19?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
+    end
 
-    click_link("Other request", match: :first)
+    it "does not allow the user to submit a blank response" do
+      visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
 
-    expect(page).to have_content("The wrong fee has been paid")
-    expect(page).to have_content("You need to pay an extra £100")
-    expect(page).to have_content("I disagree with the extra fee ")
-  end
-
-  it "does not allow the user to submit a blank response", js: true do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
-
-    click_button "Submit"
-    within(".govuk-error-summary") do
-      expect(page).to have_content "Please enter your response to the planning officer's question."
+      click_button "Submit"
+      within(".govuk-error-summary") do
+        expect(page).to have_content "Please enter your response to the planning officer's question."
+      end
     end
   end
 
-  it "displays a cancellation summary for a cancelled validation request" do
-    stub_cancelled_change_requests
-    stub_successful_get_planning_application
+  context "when state is closed" do
+    before do
+      stub_get_other_change_validation_request(
+        id: 19,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 19,
+            "state": "closed",
+            "response": "I accept the change",
+          },
+        status: 200,
+      )
+    end
 
-    visit "/other_change_validation_requests/4?change_access_id=345443543&planning_application_id=28"
+    it "can't view edit action" do
+      visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
+    end
 
-    expect(page).to have_content "Cancelled other request to change your application"
-    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
-    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
-    expect(page).to have_content "My mistake"
-    expect(page).to have_content "20 October 2021"
-    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+    it "view the page for a closed other validation request" do
+      visit "/other_change_validation_requests/19?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("My response to this request")
+      expect(page).to have_content("I accept the change")
+    end
+  end
+
+  context "when state is cancelled" do
+    before do
+      stub_get_other_change_validation_request(
+        id: 19,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 19,
+            "state": "cancelled",
+            "cancel_reason": "My mistake",
+            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+          },
+        status: 200,
+      )
+    end
+
+    it "displays a cancellation summary for a cancelled validation request" do
+      visit "/other_change_validation_requests/19?change_access_id=345443543&planning_application_id=28"
+
+      expect(page).to have_content "Cancelled other request to change your application"
+      expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+      expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+      expect(page).to have_content "My mistake"
+      expect(page).to have_content "20 October 2021"
+      expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+    end
   end
 end

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -1,115 +1,183 @@
 require "rails_helper"
 
-RSpec.describe "Description change requests", type: :system do
+RSpec.describe "Red line boundary change requests", type: :system do
   before do
     ENV["API_BEARER"] = "123"
     ENV["PROTOCOL"] = "https"
+
+    stub_successful_get_planning_application
+    stub_get_red_line_boundary_change_validation_request(
+      id: 10,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 10,
+          "state": "open",
+          "new_geojson": "",
+          "reason": nil,
+          "approved": nil,
+        },
+      status: 200,
+    )
   end
 
-  it "allows the user to accept a change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
-
-    choose "Yes, I agree with the proposed red line boundary"
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/red_line_boundary_change_validation_requests/10?change_access_id=345443543")
-                                       .with(
-                                         body: { data: { approved: true } }.to_json,
-                                         headers: headers,
-                                       )
-                                       .to_return(status: 200, body: "{}")
-
-    click_button "Submit"
-
-    expect(change_request_patch_request).to have_been_requested
-    expect(page).to have_content("Your response was updated successfully")
-  end
-
-  it "allows the user to reject a change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content("Confirm changes to your application's red line boundary")
-    choose "No, I disagree with the proposed red line boundary"
-    fill_in "Please indicate why you disagree with the proposed red line boundary.", with: "I think the boundary is wrong"
-
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/red_line_boundary_change_validation_requests/10?change_access_id=345443543")
-        .with(
-          body: { data: { approved: false, rejection_reason: "I think the boundary is wrong" } }.to_json,
-          headers: headers,
+  context "when state is open" do
+    context "accepting change request" do
+      before do
+        stub_patch_approved_red_line_boundary_change_validation_request(
+          id: 10,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          status: 200,
         )
-        .to_return(status: 200, body: "{}")
+      end
 
-    click_button "Submit"
-    expect(change_request_patch_request).to have_been_requested
-    stub_successful_get_planning_application
+      it "allows the user to accept a change request" do
+        visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
 
-    stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-        .with(headers: headers)
-        .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
-  end
+        choose "Yes, I agree with the proposed red line boundary"
 
-  it "display an error if an option has not been selected" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+        stub_successful_get_change_requests
+        click_button "Submit"
 
-    visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+        expect(page).to have_content("Your response was updated successfully")
+      end
+    end
 
-    click_button "Submit"
-    within(".govuk-error-summary") do
-      expect(page).to have_content "Please select an option"
+    context "rejecting change request" do
+      before do
+        stub_patch_rejected_red_line_boundary_change_validation_request(
+          id: 10,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          rejection_reason: "I think the boundary is wrong",
+          status: 200,
+        )
+      end
+
+      it "allows the user to reject a change request" do
+        visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content("Confirm changes to your application's red line boundary")
+        choose "No, I disagree with the proposed red line boundary"
+        fill_in "Please indicate why you disagree with the proposed red line boundary.", with: "I think the boundary is wrong"
+
+        stub_successful_get_change_requests
+        click_button "Submit"
+
+        expect(page).to have_content("Your response was updated successfully")
+      end
+
+      it "does not allow the user to reject a change request without filling in a rejection reason" do
+        visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+
+        choose "No, I disagree with the proposed red line boundary"
+
+        click_button "Submit"
+        within(".govuk-error-summary") do
+          expect(page).to have_content "Please indicate why you disagree with the proposed red line boundary."
+        end
+      end
+    end
+
+    it "display an error if an option has not been selected" do
+      visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+
+      click_button "Submit"
+      within(".govuk-error-summary") do
+        expect(page).to have_content "Please select an option"
+      end
+    end
+
+    it "can't view show action" do
+      visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
     end
   end
 
-  it "does not allow the user to reject a change request without filling in a rejection reason" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is closed" do
+    context "when approved" do
+      before do
+        stub_get_red_line_boundary_change_validation_request(
+          id: 10,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          response_body:
+            {
+              "id": 10,
+              "state": "closed",
+              "approved": true,
+            },
+          status: 200,
+        )
+      end
 
-    visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+      it "displays the correct label for an accepted boundary change request" do
+        visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
 
-    choose "No, I disagree with the proposed red line boundary"
+        expect(page).to have_content("Agreed with suggested boundary changes")
+      end
 
-    click_button "Submit"
-    within(".govuk-error-summary") do
-      expect(page).to have_content "Please indicate why you disagree with the proposed red line boundary."
+      it "can't view edit action" do
+        visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+        expect(page).to have_content("Not Found")
+      end
+    end
+
+    context "when not approved" do
+      before do
+        stub_get_red_line_boundary_change_validation_request(
+          id: 10,
+          planning_id: 28,
+          change_access_id: 345_443_543,
+          response_body:
+            {
+              "id": 10,
+              "state": "closed",
+              "rejection_reason": "I do not agree with this boundary",
+              "approved": false,
+            },
+          status: 200,
+        )
+      end
+
+      it "displays the correct label for a rejected boundary change request" do
+        visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content("Disagreed with suggested boundary changes")
+        expect(page).to have_content("My reason for objecting to the boundary changes:")
+        expect(page).to have_content("I do not agree with this boundary")
+      end
     end
   end
 
-  it "displays the correct label for an accepted boundary change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is cancelled" do
+    before do
+      stub_get_red_line_boundary_change_validation_request(
+        id: 10,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 10,
+            "state": "cancelled",
+            "cancel_reason": "My mistake",
+            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+          },
+        status: 200,
+      )
+    end
 
-    visit "/red_line_boundary_change_validation_requests/11?change_access_id=345443543&planning_application_id=28"
+    it "displays a cancellation summary for a cancelled validation request" do
+      visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
 
-    expect(page).to have_content("Agreed with suggested boundary changes")
-  end
-
-  it "displays the correct label for a rejected boundary change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-    stub_rejected_patch_with_reason
-
-    visit "/red_line_boundary_change_validation_requests/35?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content("Disagreed with suggested boundary changes")
-    expect(page).to have_content("My reason for objecting to the boundary changes:")
-    expect(page).to have_content("I do not agree with this boundary")
-  end
-
-  it "displays a cancellation summary for a cancelled validation request" do
-    stub_cancelled_change_requests
-    stub_successful_get_planning_application
-
-    visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content "Cancelled request to change your application's red line boundary"
-    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
-    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
-    expect(page).to have_content "My mistake"
-    expect(page).to have_content "20 October 2021"
-    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content "Cancelled request to change your application's red line boundary"
+      expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+      expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+      expect(page).to have_content "My mistake"
+      expect(page).to have_content "20 October 2021"
+      expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+    end
   end
 end

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -6,60 +6,127 @@ RSpec.describe "Document change requests", type: :system do
   before do
     ENV["API_BEARER"] = "123"
     ENV["PROTOCOL"] = "https"
+
+    stub_successful_get_planning_application
+    stub_get_replacement_document_validation_request(
+      id: 8,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 8,
+          "state": "open",
+          "old_document": {
+            "name": "20210512_162911.jpg",
+            "invalid_document_reason": "Its a chicken coop not a floor plan.",
+          },
+        },
+      status: 200,
+    )
   end
 
-  it "allows the user to view a document change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is open" do
+    before do
+      stub_patch_replacement_document_validation_request(
+        id: 8,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        status: 200,
+      )
+    end
 
-    visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
+    it "allows the user to view a document change request" do
+      visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
 
-    expect(page).to have_content("Name of file on submission:")
-    expect(page).to have_content("20210512_162911.jpg")
-    expect(page).to have_content("Its a chicken coop not a floor plan.")
-    expect(page).to have_content("Upload a replacement file")
+      expect(page).to have_content("Name of file on submission:")
+      expect(page).to have_content("20210512_162911.jpg")
+      expect(page).to have_content("Its a chicken coop not a floor plan.")
+      expect(page).to have_content("Upload a replacement file")
+    end
+
+    it "allows the user to update a document change request" do
+      visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
+
+      attach_file("Upload a replacement file", "spec/fixtures/images/proposed-floorplan.png")
+
+      click_button "Submit"
+    end
+
+    it "can't view show action" do
+      visit "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
+    end
   end
 
-  it "allows the user to update a document change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is closed" do
+    before do
+      stub_get_replacement_document_validation_request(
+        id: 8,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 8,
+            "state": "closed",
+            "old_document": {
+              "name": "paul-volkmer.jpg",
+              "invalid_document_reason": "Its a galaxy.",
+            },
+            "new_document": {
+              "name": "max-baskakov-catunsplash.jpg",
+              "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBRZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--772d855213ddd9220ca829cec75caaafe68a3fc8/max-baskakov-catunsplash.jpg",
+            },
+          },
+        status: 200,
+      )
+    end
 
-    visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
+    it "displays the new document in the show page for a closed description change request" do
+      visit "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28"
 
-    attach_file("Upload a replacement file", "spec/fixtures/images/proposed-floorplan.png")
-    change_request_patch_request = stub_request(:patch, "https://default.bops-care.link/api/v1/planning_applications/28/replacement_document_validation_requests/8?change_access_id=345443543")
-    .to_return(status: 200, body: "", headers: {})
+      expect(page).to have_content "Name of file on submission:"
+      expect(page).to have_content "paul-volkmer.jpg"
+      expect(page).to have_content "Case officer's reason for requesting the document:"
+      expect(page).to have_content "Its a galaxy."
+      expect(page).to have_content "Document uploaded:"
+      expect(page).to have_content "max-baskakov-catunsplash.jpg"
+    end
 
-    click_button "Submit"
-    expect(change_request_patch_request).to have_been_requested
-    stub_successful_get_planning_application
+    it "can't view edit action" do
+      visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content("Not Found")
+    end
   end
 
-  it "displays the new document in the show page for a closed description change request" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
+  context "when state is cancelled" do
+    before do
+      stub_get_replacement_document_validation_request(
+        id: 8,
+        planning_id: 28,
+        change_access_id: 345_443_543,
+        response_body:
+          {
+            "id": 8,
+            "state": "cancelled",
+            "cancel_reason": "My mistake",
+            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+          },
+        status: 200,
+      )
+    end
 
-    visit "/replacement_document_validation_requests/12?change_access_id=345443543&planning_application_id=28"
+    it "displays a cancellation summary for a cancelled validation request" do
+      stub_cancelled_change_requests
+      stub_successful_get_planning_application
 
-    expect(page).to have_content "Name of file on submission:"
-    expect(page).to have_content "paul-volkmer.jpg"
-    expect(page).to have_content "Case officer's reason for requesting the document:"
-    expect(page).to have_content "Its a galaxy."
-    expect(page).to have_content "Document uploaded:"
-    expect(page).to have_content "max-baskakov-catunsplash.jpg"
-  end
+      visit "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28"
 
-  it "displays a cancellation summary for a cancelled validation request" do
-    stub_cancelled_change_requests
-    stub_successful_get_planning_application
-
-    visit "/replacement_document_validation_requests/8?change_access_id=345443543&planning_application_id=28"
-
-    expect(page).to have_content "Cancelled request to provide a replacement document"
-    expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
-    expect(page).to have_content "The officer gave the following reason for cancelling this request:"
-    expect(page).to have_content "My mistake"
-    expect(page).to have_content "20 October 2021"
-    expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+      expect(page).to have_content "Cancelled request to provide a replacement document"
+      expect(page).to have_content "This request has been cancelled. You do not have to take any further actions."
+      expect(page).to have_content "The officer gave the following reason for cancelling this request:"
+      expect(page).to have_content "My mistake"
+      expect(page).to have_content "20 October 2021"
+      expect(page).to have_link "Back", href: "/validation_requests?change_access_id=345443543&planning_application_id=28"
+    end
   end
 end

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -52,6 +52,20 @@ RSpec.describe "Change requests", type: :system do
     stub_successful_get_planning_application
 
     visit "/validation_requests?planning_application_id=28&change_access_id=345443543"
+
+    stub_get_description_change_validation_request(
+      id: 18,
+      planning_id: 28,
+      change_access_id: 345_443_543,
+      response_body:
+        {
+          "id": 18,
+          "state": "open",
+          "proposed_description": "This is a better description",
+        },
+      status: 200,
+    )
+
     click_link("Description", match: :first)
 
     expect(page).to have_content("This is a better description")


### PR DESCRIPTION
- Rather than load all the validation requests for each action, we can just use the new show resources added on the BOPS api to get the response required for our validtion request views
- Tidy up specs a bit

https://trello.com/c/pEjfRrtE/674-use-new-validation-request-api-resources-in-bops-applicant