### PR TITLE
Support multiple document uploads for additional document requests

### DIFF
--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -39,6 +39,6 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
 private
 
   def additional_document_validation_request_params
-    params.require(:additional_document_validation_request).permit(:file)
+    params.require(:additional_document_validation_request).permit(files: [])
   end
 end

--- a/app/models/bops/additional_document_validation_request.rb
+++ b/app/models/bops/additional_document_validation_request.rb
@@ -4,24 +4,24 @@ module Bops
   class AdditionalDocumentValidationRequest
     include ActiveModel::Model
 
-    attr_accessor :file, :planning_application_id, :change_access_id, :id
+    attr_accessor :files, :planning_application_id, :change_access_id, :id
 
-    validates :file, presence: true
+    validates :files, presence: true
 
     class << self
       def find(id, planning_application_id, change_access_id)
         Apis::Bops::Client.get_additional_document_validation_request(id, planning_application_id, change_access_id)
       end
 
-      def add_document(id, planning_application_id, change_access_id, file)
-        Apis::Bops::Client.patch_additional_document(id, planning_application_id, change_access_id, file)
+      def add_documents(id, planning_application_id, change_access_id, files)
+        Apis::Bops::Client.patch_additional_documents(id, planning_application_id, change_access_id, files)
       end
     end
 
     def update
       return false unless valid?
 
-      self.class.add_document(id, planning_application_id, change_access_id, file)
+      self.class.add_documents(id, planning_application_id, change_access_id, files)
     end
   end
 end

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -114,12 +114,12 @@ module Apis
           )
         end
 
-        def patch_additional_document(id, planning_application_id, change_access_id, file)
+        def patch_additional_documents(id, planning_application_id, change_access_id, files)
           request(
             http_method: :patch,
             endpoint: "#{planning_application_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "file": file,
+              "files": files,
             },
             upload_file: true,
           )

--- a/app/services/http_client.rb
+++ b/app/services/http_client.rb
@@ -24,13 +24,18 @@ class HttpClient
     HTTParty.patch(
       "#{api_base_url}#{endpoint}",
       headers: { "Authorization": authorization_header },
-      body: {
-        "new_file": params[:file],
-      },
+      body: file_params_body(params),
     )
   end
 
 private
+
+  def file_params_body(params)
+    {}.tap do |hash|
+      hash[:new_file] = params[:file] if params[:file]
+      hash[:files] = params[:files] if params[:files]
+    end
+  end
 
   def api_base
     "#{Current.local_authority}.#{ENV['API_HOST'] || 'bops-care.link'}/api/v1"

--- a/app/views/additional_document_validation_requests/_document_create_header.html.erb
+++ b/app/views/additional_document_validation_requests/_document_create_header.html.erb
@@ -4,12 +4,14 @@
 <p class="govuk-body">
   The case officer has specified below why this document is needed.
 </p>
-<p class="govuk-heading-s">What you need to do:</p>
-<ul class="govuk-list govuk-list--bullet">
-  <li>Select 'choose file' and upload a file from your device</li>
-  <li>Click save to add the file</li>
-  <li>Click submit to complete this action </li>
-</ul>
+<% if @validation_request["state"] == "open" %>
+  <p class="govuk-heading-s">What you need to do:</p>
+  <ul class="govuk-list govuk-list--bullet">
+    <li>Select 'choose files' and upload one or more files from your device</li>
+    <li>Click save to add the file(s)</li>
+    <li>Click submit to complete this action </li>
+  </ul>
+<% end %>
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <div class="govuk-!-margin-top-6">
   <p class="govuk-body"><strong>Document requested:</strong><br>

--- a/app/views/additional_document_validation_requests/edit.html.erb
+++ b/app/views/additional_document_validation_requests/edit.html.erb
@@ -24,7 +24,7 @@
 
           <div class="govuk-form-group <%= flash["error"].present? ? 'govuk-form-group govuk-form-group--error' : '' %>">
             <div class="govuk-!-padding-top-6 govuk-!-padding-bottom-4">
-              <%= form.govuk_file_field :file, label: { text: "Upload a new file", class: "govuk-label govuk-!-font-weight-bold" }, accept: acceptable_file_mime_types, required: true %>
+              <%= form.govuk_file_field :files, multiple: true, label: { text: "Upload new file(s)", class: "govuk-label govuk-!-font-weight-bold" }, accept: acceptable_file_mime_types, required: true %>
               <%= form.hidden_field :id %>
             </div>
             <div class="govuk-button-group">

--- a/app/views/additional_document_validation_requests/show.html.erb
+++ b/app/views/additional_document_validation_requests/show.html.erb
@@ -7,10 +7,20 @@
           heading: "Cancelled request to provide a new document" %>
       <% else %>
         <%= render "document_create_header"%>
-        <p class="govuk-body govuk-!-padding-top-6"><strong>Document uploaded:</strong><br>
-          <%= @validation_request["new_document"]["name"] %>
+        <p class="govuk-body govuk-!-padding-top-6">
+          <strong>Document(s) you uploaded in response:</strong>
         </p>
-        <%= image_tag(@validation_request["new_document"]["url"], class: "image-border") %>
+
+        <ul id="documents" class="govuk-list">
+          <% @validation_request["documents"].each do |document| %>
+            <li>
+              <p class="govuk-body">
+                <%= document["name"] %>
+              </p>
+              <%= image_tag(document["url"], class: "image-border") %>
+            </li>
+          <% end %>
+        </ul>
       <% end %>
 
       <div class="govuk-!-margin-top-8">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,8 +24,8 @@ en:
               blank: "Please enter your response to the planning officer's question."
         bops/additional_document_validation_request:
           attributes:
-            file:
-              blank: "Please choose a file to upload"
+            files:
+              blank: "Please choose at least one file to upload"
         bops/replacement_document_validation_request:
           attributes:
             file:

--- a/spec/models/bops/additional_document_validation_request_spec.rb
+++ b/spec/models/bops/additional_document_validation_request_spec.rb
@@ -11,8 +11,8 @@ RSpec.describe Bops::AdditionalDocumentValidationRequest, type: :model do
         expect {
           additional_document_validation_request.valid?
         }.to change {
-          additional_document_validation_request.errors[:file]
-        }.to ["Please choose a file to upload"]
+          additional_document_validation_request.errors[:files]
+        }.to ["Please choose at least one file to upload"]
       end
     end
   end

--- a/spec/services/apis/bops/client_spec.rb
+++ b/spec/services/apis/bops/client_spec.rb
@@ -96,16 +96,16 @@ RSpec.describe Apis::Bops::Client do
     end
   end
 
-  describe ".patch_additional_document" do
+  describe ".patch_additional_documents" do
     it "initializes a Request object with additional_document_validation_request_id, planning_application_id, change_access_id and file and invokes #call" do
       expect(Request).to receive(:new).with(
         :patch,
         "#{planning_application_id}/additional_document_validation_requests/5?change_access_id=#{change_access_id}",
-        { file: "file" },
+        { files: "files" },
         true,
       ).and_call_original
 
-      described_class.patch_additional_document(5, planning_application_id, change_access_id, "file")
+      described_class.patch_additional_documents(5, planning_application_id, change_access_id, "files")
     end
   end
 

--- a/spec/services/http_client_spec.rb
+++ b/spec/services/http_client_spec.rb
@@ -28,12 +28,20 @@ RSpec.describe HttpClient do
   end
 
   describe ".http_party" do
-    it "makes an HTTP party connection" do
+    it "when params is for a single file it makes an HTTP party connection" do
       expect(HTTParty).to receive(:patch).with(
         "#{url}28", { body: { new_file: "file" }, headers: { Authorization: token } }
       )
 
       described_class.new.http_party("28", { "file": "file" })
+    end
+
+    it "when params is for more than one file makes an HTTP party connection" do
+      expect(HTTParty).to receive(:patch).with(
+        "#{url}28", { body: { files: "files" }, headers: { Authorization: token } }
+      )
+
+      described_class.new.http_party("28", { "files": "files" })
     end
   end
 end

--- a/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
@@ -16,7 +16,7 @@ RSpec.configure do |config|
       )
     end
 
-    def stub_patch_additional_document_validation_request(id:, planning_id:, change_access_id:, status:)
+    def stub_patch_additional_documents_validation_request(id:, planning_id:, change_access_id:, status:)
       stub_request(
         :patch,
         "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -41,7 +41,7 @@ RSpec.describe "Document create requests", type: :system do
 
   context "Adding a document" do
     before do
-      stub_patch_additional_document_validation_request(
+      stub_patch_additional_documents_validation_request(
         id: 3,
         planning_id: 28,
         change_access_id: 345_443_543,
@@ -52,7 +52,7 @@ RSpec.describe "Document create requests", type: :system do
     it "allows the user to update a document create request" do
       visit "/additional_document_validation_requests/3/edit?change_access_id=345443543&planning_application_id=28"
 
-      attach_file("Upload a new file", "spec/fixtures/images/proposed-floorplan.png")
+      attach_file("Upload new file(s)", "spec/fixtures/images/proposed-floorplan.png")
 
       click_button "Submit"
     end
@@ -70,10 +70,16 @@ RSpec.describe "Document create requests", type: :system do
             "state": "closed",
             "document_request_type": "Floor plan",
             "document_request_reason": "No floor plan.",
-            "new_document": {
-              "name": "proposed-floorplan.jpg",
-              "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan.png",
-            },
+            "documents": [
+              {
+                "name": "proposed-floorplan.jpg",
+                "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan.png",
+              },
+              {
+                "name": "proposed-floorplan-2.jpg",
+                "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan-2.png",
+              },
+            ],
           },
         status: 200,
       )
@@ -87,6 +93,7 @@ RSpec.describe "Document create requests", type: :system do
       expect(page).to have_content "Case officer's reason for requesting the document:"
       expect(page).to have_content "No floor plan"
       expect(page).to have_content "proposed-floorplan.jpg"
+      expect(page).to have_content "proposed-floorplan-2.jpg"
     end
 
     it "can't view edit action" do


### PR DESCRIPTION
- Support multiple document uploads for additional document requests 
- Update show page to remove confusing copy only needed for the edit page
- Show documents uploaded by applicant on show page

Related PR https://github.com/unboxed/bops/pull/509

https://trello.com/c/rs1kJhqb/487-allow-multiple-file-uploads-for-a-new-document-request-on-bops-applicant