### PR TITLE
Use original and new states of geojson data for red line boundary change validation requests

### DIFF
--- a/app/views/red_line_boundary_change_validation_requests/_location_map.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/_location_map.html.erb
@@ -1,7 +1,7 @@
   <my-map
   style="width: 100%; height: 400px;"
   osVectorTilesApiKey="VgqyKyGclwrFphAv4fw2MrpNI4CnzATT"
-  <% if locals[:geojson].present? %>
-    geojsonData='<%= JSON.parse(locals[:geojson]).to_json.html_safe %>'
+  <% if geojson.present? %>
+    geojsonData='<%= JSON.parse(geojson).to_json.html_safe %>'
   <% end %>
   ></my-map>

--- a/app/views/red_line_boundary_change_validation_requests/edit.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/edit.html.erb
@@ -21,12 +21,12 @@
         <p class="govuk-body"><strong>Your original red line boundary</strong><br>
         </p>
       </div>
-      <%= render "location_map", locals: { geojson: @planning_application["boundary_geojson"] } %>
+      <%= render "location_map", geojson: @validation_request["original_geojson"] %>
       <div style="margin-top: 30px;">
         <p class="govuk-body"><strong>Proposed red line boundary</strong><br>
         </p>
       </div>
-      <%= render "location_map", locals: { geojson: @validation_request["new_geojson"] } %>
+      <%= render "location_map", geojson: @validation_request["new_geojson"] %>
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <%= render 'form' %>
     </div>

--- a/app/views/red_line_boundary_change_validation_requests/show.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/show.html.erb
@@ -14,12 +14,12 @@
           <p class="govuk-body"><strong>Your original red line boundary</strong><br>
           </p>
         </div>
-        <%= render "location_map", locals: { geojson: @planning_application["boundary_geojson"] } %>
+        <%= render "location_map", geojson: @validation_request["original_geojson"] %>
         <div style="margin-top: 30px;">
           <p class="govuk-body"><strong>Proposed red line boundary</strong><br>
           </p>
         </div>
-        <%= render "location_map", locals: { geojson: @validation_request["new_geojson"] } %>
+        <%= render "location_map", geojson: @validation_request["new_geojson"] %>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <% if @validation_request["approved"] == false %>
           <strong class="govuk-tag govuk-tag--red">

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -14,8 +14,9 @@ RSpec.describe "Red line boundary change requests", type: :system do
         {
           "id": 10,
           "state": "open",
-          "new_geojson": "",
-          "reason": nil,
+          "original_geojson": "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}",
+          "new_geojson": "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}",
+          "reason": "Not accurate",
           "approved": nil,
         },
       status: 200,
@@ -35,6 +36,16 @@ RSpec.describe "Red line boundary change requests", type: :system do
 
       it "allows the user to accept a change request" do
         visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content("Reason change is requested")
+        expect(page).to have_content("Not accurate")
+        expect(page).to have_content("Your original red line boundary")
+        expect(page).to have_content("Proposed red line boundary")
+
+        # Two maps should be displayed with the original geojson and what the proposed change was
+        map_selectors = all("my-map")
+        expect(map_selectors.first["geojsondata"]).to eq("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}")
+        expect(map_selectors.last["geojsondata"]).to eq("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}")
 
         choose "Yes, I agree with the proposed red line boundary"
 
@@ -108,6 +119,8 @@ RSpec.describe "Red line boundary change requests", type: :system do
               "id": 10,
               "state": "closed",
               "approved": true,
+              "original_geojson": "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}",
+              "new_geojson": "{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}",
             },
           status: 200,
         )
@@ -115,6 +128,14 @@ RSpec.describe "Red line boundary change requests", type: :system do
 
       it "displays the correct label for an accepted boundary change request" do
         visit "/red_line_boundary_change_validation_requests/10?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content("Your original red line boundary")
+        expect(page).to have_content("Proposed red line boundary")
+
+        # Two maps should be displayed with the original geojson and what the proposed change was
+        map_selectors = all("my-map")
+        expect(map_selectors.first["geojsondata"]).to eq("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.054597,51.537331],[-0.054588,51.537287],[-0.054453,51.537313],[-0.054597,51.537331]]]}}")
+        expect(map_selectors.last["geojsondata"]).to eq("{\"type\":\"Feature\",\"properties\":{},\"geometry\":{\"type\":\"Polygon\",\"coordinates\":[[[-0.076715,51.501166],[-0.07695,51.500673],[-0.076,51.500763],[-0.076715,51.501166]]]}}")
 
         expect(page).to have_content("Agreed with suggested boundary changes")
       end


### PR DESCRIPTION
https://trello.com/c/K4yH4Ijr/532-keep-track-record-of-previous-red-line-in-bops-applicants