### PR TITLE
Add link to public planning guides page on BoPS

### DIFF
--- a/app/views/additional_document_validation_requests/_document_create_header.html.erb
+++ b/app/views/additional_document_validation_requests/_document_create_header.html.erb
@@ -11,6 +11,9 @@
     <li>Click save to add the file(s)</li>
     <li>Click submit to complete this action </li>
   </ul>
+
+  <%= render "shared/planning_guides_link" %>
+
 <% end %>
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <div class="govuk-!-margin-top-6">

--- a/app/views/replacement_document_validation_requests/edit.html.erb
+++ b/app/views/replacement_document_validation_requests/edit.html.erb
@@ -13,6 +13,9 @@
         <li>Click save to add the file</li>
         <li>Click submit to complete this action </li>
       </ul>
+
+      <%= render "shared/planning_guides_link" %>
+
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <div class="govuk-!-margin-top-8">
         <p class="govuk-body"><strong>Name of file on submission:</strong><br>

--- a/app/views/shared/_planning_guides_link.html.erb
+++ b/app/views/shared/_planning_guides_link.html.erb
@@ -1,0 +1,4 @@
+<p class="govuk-body">
+  <%= link_to "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
+    "#{ENV['PROTOCOL']}://#{Current.local_authority}.#{ENV['API_HOST']}/planning_guides/index", class: "govuk-link", target: "_blank" %>
+</p>

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -31,6 +31,11 @@ RSpec.describe "Document create requests", type: :system do
       expect(page).to have_content("Roman theatre plan")
       expect(page).to have_content("Case officer's reason for requesting the document:")
       expect(page).to have_content("I do not see a vomitorium in this.")
+
+      expect(page).to have_link(
+        "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
+        href: "#{ENV['PROTOCOL']}://default.#{ENV['API_HOST']}/planning_guides/index",
+      )
     end
 
     it "can't view show action" do

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -42,6 +42,11 @@ RSpec.describe "Document change requests", type: :system do
       expect(page).to have_content("20210512_162911.jpg")
       expect(page).to have_content("Its a chicken coop not a floor plan.")
       expect(page).to have_content("Upload a replacement file")
+
+      expect(page).to have_link(
+        "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
+        href: "#{ENV['PROTOCOL']}://default.#{ENV['API_HOST']}/planning_guides/index",
+      )
     end
 
     it "allows the user to update a document change request" do


### PR DESCRIPTION
https://trello.com/c/r0reIVOc/709-add-stock-instructions-on-how-to-prepare-plans-to-bops-applicants-and-indicate-their-presence-to-officers-on-bops