### PR TITLE
Move due date from index to request pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@
 /yarn-error.log
 yarn-debug.log*
 .yarn-integrity
+.env

--- a/Gemfile
+++ b/Gemfile
@@ -26,6 +26,7 @@ group :development, :test do
   gem "byebug", platforms: %i[mri mingw x64_mingw]
   gem "capybara"
   gem "factory_bot_rails"
+  gem "pry"
   gem "rspec-rails", "~> 5.0.0"
   gem "rubocop", require: false
   gem "rubocop-govuk", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -80,6 +80,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     childprocess (4.1.0)
+    coderay (1.1.3)
     concurrent-ruby (1.1.10)
     crack (0.4.5)
       rexml
@@ -159,6 +160,9 @@ GEM
     parallel (1.20.1)
     parser (3.0.2.0)
       ast (~> 2.4.1)
+    pry (0.14.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     public_suffix (4.0.6)
     puma (5.6.4)
       nio4r (~> 2.0)
@@ -317,6 +321,7 @@ DEPENDENCIES
   httparty
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  pry
   puma (>= 5.3.1)
   rack-mini-profiler (~> 2.0)
   rails (~> 6.1)

--- a/app/views/additional_document_validation_requests/_document_create_header.html.erb
+++ b/app/views/additional_document_validation_requests/_document_create_header.html.erb
@@ -1,28 +1,25 @@
-<h1 class="govuk-heading-l">
-  Provide a new document
-</h1>
-<p class="govuk-body">
-  The case officer has specified below why this document is needed.
-</p>
+<h1 class="govuk-heading-l"><%= t(".title") %></h1>
+<p class="govuk-body"><%= t(".the_case_officer") %></p>
 <% if @validation_request["state"] == "open" %>
-  <p class="govuk-heading-s">What you need to do:</p>
+  <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
   <ul class="govuk-list govuk-list--bullet">
-    <li>Select 'choose files' and upload one or more files from your device</li>
-    <li>Click save to add the file(s)</li>
-    <li>Click submit to complete this action </li>
+    <li><%= t(".select_choose_files") %></li>
+    <li><%= t(".click_save_to") %></li>
+    <li><%= t(".click_submit_to") %></li>
   </ul>
-
+  <div class="govuk-inset-text">
+    <%= t(".if_your_response", date: date_due(@validation_request)) %>
+  </div>
   <%= render "shared/planning_guides_link" %>
-
 <% end %>
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 <div class="govuk-!-margin-top-6">
-  <p class="govuk-body"><strong>Document requested:</strong><br>
+  <p class="govuk-body"><strong><%= t(".document_requested") %></strong><br>
     <%= @validation_request["document_request_type"] %>
   </p>
 </div>
 <div class="govuk-!-margin-top-4">
-  <p class="govuk-body"><strong>Case officer's reason for requesting the document:</strong><br>
+  <p class="govuk-body"><strong><%= t(".case_officers_reason") %></strong><br>
     <%= @validation_request["document_request_reason"] %>
   </p>
 </div>

--- a/app/views/description_change_validation_requests/edit.html.erb
+++ b/app/views/description_change_validation_requests/edit.html.erb
@@ -1,28 +1,30 @@
 <% content_for :page_title do %>
-  Description change validation request #<%= @validation_request["id"] %> - Back-Office Planning System
+  <%= t(".page_title", id:  @validation_request["id"]) %>
 <% end %>
-
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h1 class="govuk-heading-l">Confirm changes to your application description</h1>
-        <p class="govuk-body">
-          The following changes have been made to your application's description.
-        </p>
-        <p class="govuk-heading-s">What you need to do:</p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+        <p class="govuk-body"><%= t(".the_following_changes") %></p>
+        <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
         <ul class="govuk-list govuk-list--bullet">
-          <li>Select if you agree or disagree with the changes made by your case officer</li>
-          <li>If you disagree, write in the box provided your reason for disagreeing with the changes and provided your suggested wording for the new description</li>
-          <li>Click submit to complete this action </li>
+          <li><%= t(".select_if_you") %></li>
+          <li><%= t(".if_you_disagree") %></li>
+          <li><%= t(".click_submit_to") %></li>
         </ul>
+        <div class="govuk-inset-text">
+          <%= t(".if_your_response", date: date_due(@validation_request)) %>
+        </div>
         <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
         <div style="margin-top: 50px;">
-          <p class="govuk-body"><strong>Previous description</strong><br>
+          <p class="govuk-body">
+            <strong><%= t(".previous_description") %></strong><br>
             <%= @validation_request["previous_description"] %>
           </p>
         </div>
         <div style="margin-top: 30px;">
-          <p class="govuk-body"><strong>New description</strong><br>
+          <p class="govuk-body">
+            <strong><%= t(".new_description") %></strong><br>
             <%= @validation_request["proposed_description"] %>
           </p>
         </div>

--- a/app/views/other_change_validation_requests/edit.html.erb
+++ b/app/views/other_change_validation_requests/edit.html.erb
@@ -1,28 +1,30 @@
 <% content_for :page_title do %>
-  Other change validation request #<%= @validation_request["id"] %> - Back-Office Planning System
+  <%= t(".page_title", id:  @validation_request["id"]) %>
 <% end %>
-
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h1 class="govuk-heading-l">Respond to other request</h1>
-      <p class="govuk-body">
-        The following request has been made.
-      </p>
-      <p class="govuk-heading-s">What you need to do:</p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body"> <%= t(".the_following_request") %> </p>
+      <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Make changes to your application as set out by your case officer and reply in the box below stating what changes have been made</li>
-        <li>If you disagree with the suggested changes, reply stating why you disagree</li>
-        <li>Click submit to complete this action </li>
+        <li><%= t(".make_changes_to") %></li>
+        <li><%= t(".if_you_disagree") %></li>
+        <li><%= t(".click_submit_to") %></li>
       </ul>
+      <div class="govuk-inset-text">
+        <%= t(".if_your_response", date: date_due(@validation_request)) %>
+      </div>
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <div style="margin-top: 50px;">
-        <p class="govuk-body"><strong>Officer's reason for invalidating application</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".officers_reason_for") %></strong><br>
           <%= @validation_request["summary"] %>
         </p>
       </div>
       <div style="margin-top: 30px;">
-        <p class="govuk-body"><strong>How you can make your application valid</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".how_you_can") %></strong><br>
           <%= @validation_request["suggestion"] %>
         </p>
       </div>

--- a/app/views/red_line_boundary_change_validation_requests/edit.html.erb
+++ b/app/views/red_line_boundary_change_validation_requests/edit.html.erb
@@ -1,41 +1,50 @@
 <% content_for :page_title do %>
-  Red line boundary change validation request #<%= @validation_request["id"] %> - Back-Office Planning System
+  <%= t(".page_title", id:  @validation_request["id"]) %>
 <% end %>
-
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h1 class="govuk-heading-l">Confirm changes to your application's red line boundary</h1>
-      <p class="govuk-body">
-        The following changes have been made to your application's red line boundary.
-      </p>
-      <p class="govuk-heading-s">What you need to do:</p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body"><%= t(".the_following_changes") %></p>
+      <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Select if you agree or disagree with the changes made by your case officer</li>
-        <li>If you disagree, write in the box provided your reason for disagreeing.</li>
-        <li>Click submit to complete this action </li>
+        <li><%= t(".select_if_you") %></li>
+        <li><%= t(".if_you_disagree") %></li>
+        <li><%= t(".click_submit_to") %></li>
       </ul>
+      <div class="govuk-inset-text">
+        <%= t(".if_your_response", date: date_due(@validation_request)) %>
+      </div>
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <div style="margin-top: 50px;">
-        <p class="govuk-body"><strong>Reason change is requested</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".reasons_change_is") %></strong><br>
           <%= @validation_request["reason"] %>
         </p>
       </div>
       <div style="margin-top: 50px;">
-        <p class="govuk-body"><strong>Your original red line boundary</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".your_original_red") %></strong><br>
         </p>
-        <%= render "location_map", locals: {
-          geojson: @validation_request["original_geojson"],
-          accessibility_text: "An interactive map centred on your address where the original red line boundary lines are drawn to create the site outline."
-        } %>
+        <%= render(
+          "location_map",
+          locals: {
+            geojson: @validation_request["original_geojson"],
+            accessibility_text: t(".accessibility_text_original")
+          }
+        )%>
       </div>
       <div style="margin-top: 30px;">
-        <p class="govuk-body"><strong>Proposed red line boundary</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".proposed_red_line") %></strong><br>
         </p>
-        <%= render "location_map", locals: {
-          geojson: @validation_request["new_geojson"],
-          accessibility_text: "An interactive map centred on your address where the newly proposed red line boundary lines are drawn to create the site outline."
-        } %>
+        <%= render(
+          "location_map",
+          locals: {
+            geojson: @validation_request["new_geojson"],
+            accessibility_text: t(".accessibility_text_proposed")
+          }
+        ) %>
       </div>
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <%= render "form" %>

--- a/app/views/replacement_document_validation_requests/edit.html.erb
+++ b/app/views/replacement_document_validation_requests/edit.html.erb
@@ -1,33 +1,31 @@
 <% content_for :page_title do %>
-  Replacement document validation request #<%= @validation_request["id"] %> - Back-Office Planning System
+  <%= t(".page_title", id:  @validation_request["id"]) %>
 <% end %>
-
 <div class="govuk-grid-row govuk-!-margin-top-7">
   <div class="govuk-grid-column-two-thirds">
     <div class="govuk-width-container">
-      <h1 class="govuk-heading-l">
-        Provide a replacement document
-      </h1>
-      <p class="govuk-body">
-        The case officer has specified below why this document needs replacing.
-      </p>
-      <p class="govuk-heading-s">What you need to do:</p>
+      <h1 class="govuk-heading-l"><%= t(".title") %></h1>
+      <p class="govuk-body"><%= t(".the_case_officer") %></p>
+      <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
       <ul class="govuk-list govuk-list--bullet">
-        <li>Select 'choose file' and upload a replacement file from your device</li>
-        <li>Click save to add the file</li>
-        <li>Click submit to complete this action </li>
+        <li><%= t(".select_choose_file") %></li>
+        <li><%= t(".click_save_to") %></li>
+        <li><%= t(".click_submit_to") %></li>
       </ul>
-
+      <div class="govuk-inset-text">
+        <%= t(".if_your_response", date: date_due(@validation_request)) %>
+      </div>
       <%= render "shared/planning_guides_link" %>
-
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
       <div class="govuk-!-margin-top-8">
-        <p class="govuk-body"><strong>Name of file on submission:</strong><br>
+        <p class="govuk-body">
+          <strong><%= t(".name_of_file") %></strong><br>
           <%= @validation_request["old_document"]["name"] %>
         </p>
       </div>
       <div class="govuk-!-margin-top-6">
-        <p class="govuk-body"><strong>The reason the file needs replacing:</strong><br>
+        <p class="govuk-body"><strong>
+          <%= t(".the_reason_the") %></strong><br>
           <%= @validation_request["old_document"]["invalid_document_reason"] %>
         </p>
       </div>

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -1,32 +1,23 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-two-thirds">
-    <h1 class="govuk-heading-xl">Your planning application</h1>
+    <h1 class="govuk-heading-xl"><%= t(".title") %></h1>
     <p class="govuk-body">
-      <strong>At:</strong> <%= full_address(@planning_application) %> <br>
-      <strong>Date received:</strong> <%= date_received(@planning_application) %> <br>
-      <strong>Application number: </strong> <%= reference(@planning_application) %> <br>
+      <strong><%= t(".at") %></strong>
+      <%= full_address(@planning_application) %><br>
+      <strong><%= t(".date_received") %></strong>
+      <%= date_received(@planning_application) %><br>
+      <strong><%= t(".application_number") %></strong>
+      <%= reference(@planning_application) %><br>
       <br>
     </p>
-    <p class="govuk-body">
-      The case officer working on your application has requested changes to your planning application.
-    </p>
-    <div class="govuk-inset-text">
-      <p class="govuk-body">
-        If requested changes are not received within <strong> 15 working days </strong>
-        of the request being made, your application may be returned and your payment refunded
-        or changes will be automatically accepted.
-      </p>
-    </div>
-    <p class="govuk-heading-s">What you need to do:</p>
+    <p class="govuk-body"><%= t(".the_case_officer") %></p>
+    <p class="govuk-heading-s"><%= t(".what_you_need") %></p>
     <ul class="govuk-list govuk-list--bullet">
-      <li>Each link below requires a separate action.</li>
-      <li>Click on each link to see what action is required.</li>
-      <li>Once you have submitted an action, you can no longer make changes to it. The status for that action will change to completed. </li>
-      <li>You need to complete all actions before your case officer can proceed with your planning application.</li>
+      <li><%= t(".each_link_below") %></li>
+      <li><%= t(".click_on_each") %></li>
+      <li><%= t(".once_you_have") %></li>
+      <li><%= t(".you_need_to") %></li>
     </ul>
-    <p class="govuk-body">Where additional information or documents have been requested
-      you will have the opportunity to disagree with the request. However it will take <strong> 15 days</strong> for the
-      planning officer to process your request and review new changes. </p>
   </div>
 </div>
 <div class="govuk-grid-row">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -5,7 +5,7 @@ en:
       click_save_to: Click save to add the file
       click_submit_to: Click submit to complete this action
       document_requested: "Document requested:"
-      if_your_response: "If your response is not received by %{date} your application will be returned to you and your payment refunded."
+      if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
       select_choose_file: "Select 'choose file' and upload a file from your device"
       the_case_officer: The case officer has specified below why this document is needed.
       title: Provide a new document
@@ -16,7 +16,7 @@ en:
       if_you_disagree: If you disagree, write in the box provided your reason for disagreeing with the changes and provided your suggested wording for the new description
       if_your_response: If your response is not received by %{date} the proposed description will be automatically accepted for use with your application. This is to avoid delays in making a determination.
       new_description: New description
-      page_title: Description change validation request %{id} - Back-Office Planning System
+      page_title: "Description change validation request #%{id} - Back-Office Planning System"
       previous_description: Previous description
       select_if_you: Select if you agree or disagree with the changes made by your case officer
       the_following_changes: The following changes have been made to your application's description.
@@ -30,7 +30,7 @@ en:
       if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
       make_changes_to: Make changes to your application as set out by your case officer and reply in the box below stating what changes have been made
       officers_reason_for: Officer's reason for invalidating application
-      page_title: "Other change validation request %{id} - Back-Office Planning System"
+      page_title: "Other change validation request #%{id} - Back-Office Planning System"
       the_following_request: The following request has been made.
       title: Respond to other request
       what_you_need: "What you need to do:"
@@ -55,7 +55,7 @@ en:
       click_submit_to: Click submit to complete this action
       if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
       name_of_file: "Name of file on submission:"
-      page_title: Replacement document validation request %{id} - Back-Office Planning System
+      page_title: "Replacement document validation request #%{id} - Back-Office Planning System"
       select_choose_file: Select 'choose file' and upload a replacement file from your device
       the_case_officer: The case officer has specified below why this document needs replacing.
       the_reason_the: "The reason the file needs replacing:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,15 @@
 en:
+  additional_document_validation_requests:
+    document_create_header:
+      case_officers_reason: "Case officer's reason for requesting the document:"
+      click_save_to: Click save to add the file
+      click_submit_to: Click submit to complete this action
+      document_requested: "Document requested:"
+      if_your_response: "If your response is not received by %{date} your application will be returned to you and your payment refunded."
+      select_choose_file: "Select 'choose file' and upload a file from your device"
+      the_case_officer: The case officer has specified below why this document is needed.
+      title: Provide a new document
+      what_you_need: "What you need to do:"
   red_line_boundary_change_validation_requests:
     edit:
       accessibility_text_original: An interactive map centred on your address where the original red line boundary lines are drawn to create the site outline.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,16 @@
 en:
+  validation_requests:
+    index:
+      application_number: "Application number:"
+      at: "At:"
+      click_on_each: Click on each link to see what action is required.
+      date_received: "Date received:"
+      each_link_below: Each link below requires a separate action.
+      once_you_have: Once you have submitted an action, you can no longer make changes to it. The status for that action will change to completed.
+      the_case_officer: The case officer working on your application has requested changes to your planning application.
+      title: Your planning application
+      what_you_need: "What you need to do:"
+      you_need_to: You need to complete all actions before your case officer can proceed with your planning application.
   errors:
     format: "%{message}"
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,18 @@ en:
       the_case_officer: The case officer has specified below why this document is needed.
       title: Provide a new document
       what_you_need: "What you need to do:"
+  other_change_validation_requests:
+    edit:
+      click_submit_to: Click submit to complete this action
+      how_you_can: How you can make your application valid
+      if_you_disagree: If you disagree with the suggested changes, reply stating why you disagree
+      if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
+      make_changes_to: Make changes to your application as set out by your case officer and reply in the box below stating what changes have been made
+      officers_reason_for: Officer's reason for invalidating application
+      page_title: "Other change validation request %{id} - Back-Office Planning System"
+      the_following_request: The following request has been made.
+      title: Respond to other request
+      what_you_need: "What you need to do:"
   red_line_boundary_change_validation_requests:
     edit:
       accessibility_text_original: An interactive map centred on your address where the original red line boundary lines are drawn to create the site outline.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -1,4 +1,19 @@
 en:
+  red_line_boundary_change_validation_requests:
+    edit:
+      accessibility_text_original: An interactive map centred on your address where the original red line boundary lines are drawn to create the site outline.
+      accessibility_text_proposed: An interactive map centred on your address where the newly proposed red line boundary lines are drawn to create the site outline.
+      click_submit_to: Click submit to complete this action
+      if_you_disagree: If you disagree, write in the box provided your reason for disagreeing.
+      if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
+      page_title: "Red line boundary change validation request #%{id} - Back-Office Planning System"
+      proposed_red_line: Proposed red line boundary
+      reason_change_is: Reason change is requested
+      select_if_you: Select if you agree or disagree with the changes made by your case officer
+      the_following_changes: The following changes have been made to your application's red line boundary.
+      title: Confirm changes to your application's red line boundary
+      what_you_need: "What you need to do:"
+      your_original_red: Your original red line boundary
   validation_requests:
     index:
       application_number: "Application number:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,6 +10,18 @@ en:
       the_case_officer: The case officer has specified below why this document is needed.
       title: Provide a new document
       what_you_need: "What you need to do:"
+  description_change_validation_requests:
+    edit:
+      click_submit_to: Click submit to complete this action
+      if_you_disagree: If you disagree, write in the box provided your reason for disagreeing with the changes and provided your suggested wording for the new description
+      if_your_response: If your response is not received by %{date} the proposed description will be automatically accepted for use with your application. This is to avoid delays in making a determination.
+      new_description: New description
+      page_title: Description change validation request %{id} - Back-Office Planning System
+      previous_description: Previous description
+      select_if_you: Select if you agree or disagree with the changes made by your case officer
+      the_following_changes: The following changes have been made to your application's description.
+      title: Confirm changes to your application description
+      what_you_need: "What you need to do:"
   other_change_validation_requests:
     edit:
       click_submit_to: Click submit to complete this action

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -49,6 +49,18 @@ en:
       title: Confirm changes to your application's red line boundary
       what_you_need: "What you need to do:"
       your_original_red: Your original red line boundary
+  replacement_document_validation_requests:
+    edit:
+      click_save_to: Click save to add the file
+      click_submit_to: Click submit to complete this action
+      if_your_response: If your response is not received by %{date} your application will be returned to you and your payment refunded.
+      name_of_file: "Name of file on submission:"
+      page_title: Replacement document validation request %{id} - Back-Office Planning System
+      select_choose_file: Select 'choose file' and upload a replacement file from your device
+      the_case_officer: The case officer has specified below why this document needs replacing.
+      the_reason_the: "The reason the file needs replacing:"
+      title: Provide a replacement document
+      what_you_need: "What you need to do:"
   validation_requests:
     index:
       application_number: "Application number:"

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe "Document create requests", type: :system do
           "state": "open",
           "document_request_type": "Roman theatre plan",
           "document_request_reason": "I do not see a vomitorium in this.",
+          "response_due": "2022-7-1",
         },
       status: 200,
     )
@@ -26,6 +27,10 @@ RSpec.describe "Document create requests", type: :system do
   context "when state is open" do
     it "allows the user to view an open document create request" do
       visit "/additional_document_validation_requests/3/edit?change_access_id=345443543&planning_application_id=28"
+
+      expect(page).to have_content(
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+      )
 
       expect(page).to have_content("Document requested:")
       expect(page).to have_content("Roman theatre plan")

--- a/spec/system/description_change_request_spec.rb
+++ b/spec/system/description_change_request_spec.rb
@@ -14,6 +14,7 @@ RSpec.describe "Description change requests", type: :system do
         {
           "id": 22,
           "state": "open",
+          "response_due": "2022-7-1",
         },
       status: 200,
     )
@@ -32,6 +33,10 @@ RSpec.describe "Description change requests", type: :system do
 
       it "allows the user to accept a change request" do
         visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content(
+          "If your response is not received by 1 July 2022 the proposed description will be automatically accepted for use with your application.",
+        )
 
         choose "Yes, I agree with the changes made"
 

--- a/spec/system/other_change_validation_request_spec.rb
+++ b/spec/system/other_change_validation_request_spec.rb
@@ -16,6 +16,7 @@ RSpec.describe "Other change requests", type: :system do
           "state": "open",
           "summary": "You applied for the wrong sort of certificate",
           "suggestion": "Please confirm you want a Lawful Development certificate",
+          "response_due": "2022-7-1",
         },
       status: 200,
     )
@@ -34,6 +35,10 @@ RSpec.describe "Other change requests", type: :system do
 
     it "allows the user to provide a response" do
       visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
+
+      expect(page).to have_content(
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+      )
 
       expect(page).to have_content("You applied for the wrong sort of certificate")
       expect(page).to have_content("Please confirm you want a Lawful Development certificate")

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -17,6 +17,7 @@ RSpec.describe "Red line boundary change requests", type: :system do
           "new_geojson": "",
           "reason": nil,
           "approved": nil,
+          "response_due": "2022-7-1",
         },
       status: 200,
     )
@@ -35,6 +36,10 @@ RSpec.describe "Red line boundary change requests", type: :system do
 
       it "allows the user to accept a change request" do
         visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
+
+        expect(page).to have_content(
+          "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+        )
 
         choose "Yes, I agree with the proposed red line boundary"
 

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -20,6 +20,7 @@ RSpec.describe "Document change requests", type: :system do
             "name": "20210512_162911.jpg",
             "invalid_document_reason": "Its a chicken coop not a floor plan.",
           },
+          "response_due": "2022-7-1",
         },
       status: 200,
     )
@@ -37,6 +38,10 @@ RSpec.describe "Document change requests", type: :system do
 
     it "allows the user to view a document change request" do
       visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
+
+      expect(page).to have_content(
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+      )
 
       expect(page).to have_content("Name of file on submission:")
       expect(page).to have_content("20210512_162911.jpg")

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -38,15 +38,6 @@ RSpec.describe "Change requests", type: :system do
     expect(page).to have_content("00000028")
   end
 
-  it "displays the due date of the latest change request in the index page" do
-    stub_successful_get_change_requests
-    stub_successful_get_planning_application
-
-    visit "/validation_requests?planning_application_id=28&change_access_id=345443543"
-
-    expect(page).to have_content("If requested changes are not received within 15 working days")
-  end
-
   it "displays the description of the change request on the change request page" do
     stub_successful_get_change_requests
     stub_successful_get_planning_application
@@ -62,6 +53,7 @@ RSpec.describe "Change requests", type: :system do
           "id": 18,
           "state": "open",
           "proposed_description": "This is a better description",
+          "response_due": "2022-7-1",
         },
       status: 200,
     )


### PR DESCRIPTION
### What

- Remove the hard-coded '15 days' due date from the requests index page.
- Show the due date for each request on the edit request page.
- Move some strings to locale files.

Linked to https://github.com/unboxed/bops/pull/672 (ensures correct due date is pulled through for description change requests).

### Story card

https://trello.com/c/O1qA5sVv/682-support-both-15-day-validation-and-5-day-post-validation-time-limited-request-from-applicants-3

### Screenshots
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 01" src="https://user-images.githubusercontent.com/25392162/175339716-c8a5ff78-aa1c-4f63-b44e-1b0ee80d169e.png">
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 08" src="https://user-images.githubusercontent.com/25392162/175339729-ae4eb383-ac44-4e36-b5cf-8bec78e5fc07.png">
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 17" src="https://user-images.githubusercontent.com/25392162/175339738-c3697b59-11c0-4879-adfa-a935c8ee085b.png">
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 27" src="https://user-images.githubusercontent.com/25392162/175339748-4af0e4cd-bcd8-4b87-addd-c9f79fd2fd5c.png">
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 39" src="https://user-images.githubusercontent.com/25392162/175339759-87f74b65-1cb5-4189-b890-c2fe907701a0.png">
<img width="60%" alt="Screenshot 2022-06-23 at 16 40 51" src="https://user-images.githubusercontent.com/25392162/175339772-7de34de1-9d24-44d9-b35c-8a5f1a31461f.png">

