### PR TITLE
Add accessibility statement

### DIFF
--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,0 +1,3 @@
+class PagesController < ApplicationController
+  def accessibility; end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -8,4 +8,20 @@ module ApplicationHelper
   def feedback_email(current_local_authority)
     FEEDBACK_EMAILS[current_local_authority.to_sym]
   end
+
+  def formatted_phone_number
+    number_to_phone(
+      contact_details[:phone_number],
+      delimiter: " ",
+      pattern: /(\d{5})(\d{3})(\d{3})$/,
+    )
+  end
+
+  def contact_details
+    @contact_details ||= all_contact_details[current_local_authority].with_indifferent_access
+  end
+
+  def all_contact_details
+    YAML.load_file(Rails.root.join("config/contact_details.yml"))
+  end
 end

--- a/app/views/pages/accessibility.html.erb
+++ b/app/views/pages/accessibility.html.erb
@@ -1,0 +1,117 @@
+<% content_for :page_title do %>
+  <%= t(".page_title", local_authority: current_local_authority.titleize) %>
+<% end %>
+<div class="govuk-width-container">
+  <%= link_to("Back", :back, class: "govuk-back-link") %>
+  <main class="govuk-main-wrapper">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading-xl">
+          <%= t(".title", local_authority: current_local_authority.titleize) %>
+        </h1>
+        <p class="govuk-body">
+          <%= t(
+            ".council_is_committed",
+            local_authority: current_local_authority.titleize
+          ) %>
+        </p>
+        <p class="govuk-body"><%= t(".this_accessibility_statement") %></p>
+        <p class="govuk-body">
+          <%= t(
+            ".this_website_is",
+            local_authority: current_local_authority.titleize
+          ) %>
+        </p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><%= t(".change_colours_contrast") %></li>
+          <li><%= t(".zoom_in_up") %></li>
+          <li><%= t(".navigate_most_of") %></li>
+          <li><%= t(".navigate_most_of_2") %></li>
+          <li><%= t(".listen_to_most") %></li>
+        </ul>
+        <p class="govuk-body"><%= t(".we_have_also") %></p>
+        <p class="govuk-body">
+          <%= t(
+            ".ability_net_has",
+            link: link_to("AbilityNet", "https://mcmw.abilitynet.org.uk", class: "govuk-link")
+          ).html_safe %>
+        </p>
+        <h2 class="govuk-heading-m"><%= t(".how_accessible_this") %></h2>
+        <p class="govuk-body"><%= t(".we_know_some") %></p>
+        <ul class="govuk-list govuk-list--bullet">
+          <li><%= t(".interactive_map_content") %></li>
+          <li><%= t(".no_validation_on") %></li>
+        </ul>
+        <h2 class="govuk-heading-m"><%= t(".feedback_and_contact") %></h2>
+        <p class="govuk-body"><%= t(".if_you_need") %></p>
+        <ul class="govuk-list">
+          <li>
+            <%= t(
+              ".email",
+              email_address: contact_details[:email_address]
+            ).html_safe %>
+          </li>
+          <li>
+            <%= t(".call", phone_number: formatted_phone_number).html_safe %>
+          </li>
+        </ul>
+        <p class="govuk-body"><%= t(".we_will_consider") %></p>
+        <p class="govuk-body"><%= t(".if_you_cannot") %></p>
+        <h2 class="govuk-heading-m">
+          <%= t(".reporting_accessibility_problems") %>
+        </h2>
+        <p class="govuk-body"><%= t(".we_are_always") %></p>
+        <ul class="govuk-list">
+          <% contact_details[:postal_address].split(",").each do |line| %>
+            <li><strong><%= line %></strong></li>
+          <% end %>
+        </ul>
+        <h2 class="govuk-heading-m"><%= t(".enforcement_procedure") %></h2>
+        <p class="govuk-body">
+          <%= t(
+          ".the_equality_and",
+          link: link_to(t(".the_equality_and_link"), "https://www.equalityadvisoryservice.com", class: "govuk-link")
+          ).html_safe %>
+        </p>
+        <h2 class="govuk-heading-m"><%= t(".contacting_us_by") %></h2>
+        <p class="govuk-body"><%= t(".we_provide_a") %></p>
+        <p class="govuk-body"><%= t(".our_offices_have") %></p>
+        <h2 class="govuk-heading-m">
+          <%= t(".technical_information_about") %>
+        </h2>
+        <p class="govuk-body">
+          <%= t(
+            ".council_is_committed",
+            local_authority: current_local_authority.titleize
+          ) %>
+        </p>
+        <h2 class="govuk-heading-m"><%= t(".compliance_status") %></h2>
+        <p class="govuk-body">
+          <%= t(
+            ".this_website_is_2",
+            link: link_to(t(".this_website_is_2_link"), "https://www.w3.org/TR/WCAG21", class: "govuk-link")
+          ).html_safe %>
+        </p>
+        <h2 class="govuk-heading-m"><%= t(".content_that_is") %></h2>
+        <h3 class="govuk-heading-s"><%= t(".pdfs_and_other") %></h3>
+        <p class="govuk-body"><%= t(".we_aim_to") %></p>
+        <h3 class="govuk-heading-s"><%= t(".maps") %></h3>
+        <p class="govuk-body">
+          <%= t(
+            ".we_use_maps",
+            link: link_to(t(".we_use_maps_link"), "https://github.com/theopensystemslab/map/issues/142", class: "govuk-link")
+          ).html_safe %>
+        </p>
+        <h2 class="govuk-heading-m"><%= t(".preparation_of_this") %></h2>
+        <p class="govuk-body"><%= t(".this_statement_was") %></p>
+        <p class="govuk-body"><%= t(".we_used_this") %></p>
+        <p class="govuk-body">
+          <%= t(
+            ".you_can_read",
+            link: link_to(t(".you_can_read_link"), "https://bops.digital/Accessibility-Assessment", class: "govuk-link")
+          ).html_safe %>
+        </p>
+      </div>
+    </div>
+  </main>
+</div>

--- a/app/views/partials/_footer.html.erb
+++ b/app/views/partials/_footer.html.erb
@@ -2,7 +2,16 @@
   <div class="govuk-width-container ">
     <div class="govuk-footer__meta">
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
+        <h2 class="govuk-visually-hidden"><%= t(".support_links")%></h2>
+        <ul class="govuk-footer__inline-list">
+          <li class="govuk-footer__inline-list-item">
+            <%= link_to(
+              t(".accessibility"),
+              accessibility_path,
+              class: "govuk-footer__link"
+            )%>
+          </li>
+        </ul>
         <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
         </svg>

--- a/config/contact_details.yml
+++ b/config/contact_details.yml
@@ -1,0 +1,12 @@
+buckinghamshire:
+  email_address: planning.digital@buckinghamshire.gov.uk
+  phone_number: "03001316000"
+  postal_address: Directorate for Planning, Growth and Sustainability, Planning and Environment, Buckinghamshire Council, The Gateway, Gatehouse Road, Aylesbury, HP19 8FF
+lambeth:
+  email_address: digitalplanning@lambeth.gov.uk
+  phone_number: "02079261180"
+  postal_address: Planning, London Borough of Lambeth, PO Box 734, Winchester, SO23 5DG
+southwark:
+  email_address: digital.projects@southwark.gov.uk
+  phone_number: "02075255403"
+  postal_address: Planning Department, Southwark Council, PO BOX 64529, London, SE1P 5LX

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -34,6 +34,58 @@ en:
       the_following_request: The following request has been made.
       title: Respond to other request
       what_you_need: "What you need to do:"
+  pages:
+    accessibility:
+      ability_net_has: "%{link} has advice on making your device easier to use if you have a disability."
+      call: Call <strong>%{phone_number}</strong>
+      change_colours_contrast: change colours, contrast levels and fonts
+      compliance_status: Compliance status
+      contacting_us_by: Contacting us by phone or visiting us in person
+      content_that_is: "Content that's not within the scope of the accessibility regulations"
+      council_is_committed: "%{local_authority} Council is committed to making its websites accessible, in accordance with the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018."
+      email: Email <strong>%{email_address}</strong>
+      enforcement_procedure: Enforcement procedure
+      feedback_and_contact: Feedback and contact information
+      how_accessible_this: How accessible this website is
+      if_you_cannot: "If you cannot view the map on our 'contact us' page, call or email us for directions."
+      if_you_need: "If you need information on this website in a different format like accessible PDF, large print, easy read, audio recording or braille:"
+      interactive_map_content: Interactive map content for red line boundary changes
+      listen_to_most: listen to most of the website using a screen reader (including the most recent versions of JAWS, NVDA and VoiceOver)
+      maps: Maps
+      navigate_most_of: navigate most of the website using just a keyboard
+      navigate_most_of_2: navigate most of the website using speech recognition software
+      no_validation_on: No validation on submission, impacting those with motor impairments
+      our_offices_have: Our offices have audio induction loops, or if you contact us before your visit we can arrange a British Sign Language (BSL) interpreter.
+      pdfs_and_other: PDFs and other documents
+      page_title: "Accessibility statement for %{local_authority} Council Back-office Planning System"
+      preparation_of_this: Preparation of this accessibility statement
+      reporting_accessibility_problems: Reporting accessibility problems with this website
+      technical_information_about: "Technical information about this website's accessibility"
+      the_equality_and: "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
+(the 'accessibility regulations'). If you're not happy with how we respond to your complaint, %{link}."
+      the_equality_and_link: contact the Equality Advisory and Support Service (EASS)
+      this_accessibility_statement: This accessibility statement applies to publicly available pages of the Back-office planning system.
+      this_statement_was: This statement was prepared on 1st June 2022. This website was last tested on 12th May 2022. The test was carried out by the Digital Accessibility Centre.
+      this_website_is: "This website is run by %{local_authority} Council. We want as many people as possible to be able to use this website. For example, that means you should be able to:"
+      this_website_is_2: This website is fully compliant with the %{link} AA standard.
+      this_website_is_2_link: Web Content Accessibility Guidelines version 2.1
+      title: Accessibility statement for %{local_authority} Council Back-office Planning System
+      we_aim_to: We aim to not use PDFs and use HTML or other accessible formats wherever possible.
+      we_are_always: "We're always looking to improve the accessibility of this website. If you find any problems not listed on this page or think we're not meeting accessibility requirements, contact:"
+      we_have_also: "We've also made the website text as simple as possible to understand."
+      we_know_some: "We know some parts of this website are not fully accessible:"
+      we_provide_a: We provide a text relay service for people who are D/deaf, hearing impaired or have a speech impediment.
+      we_use_maps: We use maps to show the digital red line boundary you have submitted and suggested changes to the boundary that may be necessary. You can find out more about our plan to improve the accessibility of this %{link}.
+      we_use_maps_link: webpage
+      we_used_this: We used this approach to deciding on a sample of pages to test two journeys, one covering the responding to requests for changes to a planning application and another relating to finding and viewing information about how to correctly prepare plans and drawings.
+      we_will_consider: "We'll consider your request and get back to you in 5 working days."
+      you_can_read: You can read the full accessibility test report %{link}.
+      you_can_read_link: here
+      zoom_in_up: zoom in up to 300% without the text spilling off the screen
+  partials:
+    footer:
+      accessibility: Accessibility statement
+      support_links: Support links
   red_line_boundary_change_validation_requests:
     edit:
       accessibility_text_original: An interactive map centred on your address where the original red line boundary lines are drawn to create the site outline.

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,4 +7,8 @@ Rails.application.routes.draw do
   resources :additional_document_validation_requests, only: %i[show edit update]
   resources :other_change_validation_requests, only: %i[show edit update]
   resources :red_line_boundary_change_validation_requests, only: %i[show edit update]
+
+  controller "pages" do
+    get :accessibility, action: :accessibility
+  end
 end

--- a/spec/system/accessibility_page_spec.rb
+++ b/spec/system/accessibility_page_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+RSpec.describe "accessibility page", type: :system do
+  let(:contact_details) do
+    {
+      default: {
+        email_address: "planning@default.gov.uk",
+        phone_number: "01234123123",
+        postal_address: "Planning, 123 High Street, Big City, AB3 4EF",
+      },
+    }.deep_stringify_keys
+  end
+
+  before do
+    ENV["API_BEARER"] = "123"
+    ENV["PROTOCOL"] = "https"
+    stub_successful_get_change_requests
+    stub_successful_get_planning_application
+
+    allow(YAML).to receive(:load_file).and_call_original
+
+    allow(YAML)
+      .to receive(:load_file)
+      .with(Rails.root.join("config/contact_details.yml"))
+      .and_return(contact_details)
+  end
+
+  it "lets the user navigate to the page" do
+    visit(
+      validation_requests_path(
+        planning_application_id: 28,
+        change_access_id: 345_443_543,
+      ),
+    )
+
+    within("footer") { click_link("Accessibility statement") }
+
+    expect(page).to have_content(
+      "Accessibility statement for Default Council Back-office Planning System",
+    )
+
+    expect(page).to have_content("Email planning@default.gov.uk")
+    expect(page).to have_content("Call 01234 123 123")
+    expect(page).to have_content("123 High Street")
+  end
+end


### PR DESCRIPTION
### What

- Add statement at '/accessibility'
- Add footer link to page

### Storycard

https://trello.com/c/yxsCI1y6/1019-add-accessibility-statement-to-bops-applicant-footer

### Screenshots

Statement:
<img src='https://user-images.githubusercontent.com/25392162/177601294-e3bfd870-ff7b-44f8-b393-2f7e0c4b585b.png' width='60%'>

Footer link:
<img src='https://user-images.githubusercontent.com/25392162/177601301-104c5a52-06e6-4635-85ba-3ab9cd24ea9b.png' width='60%'>
