### PR TITLE
Don't show return and refund information for post-validation request

### DIFF
--- a/app/views/additional_document_validation_requests/_document_create_header.html.erb
+++ b/app/views/additional_document_validation_requests/_document_create_header.html.erb
@@ -7,9 +7,11 @@
     <li><%= t(".click_save_to") %></li>
     <li><%= t(".click_submit_to") %></li>
   </ul>
-  <div class="govuk-inset-text">
-    <%= t(".if_your_response", date: date_due(@validation_request)) %>
-  </div>
+  <% unless @validation_request["post_validation"] %>
+    <div class="govuk-inset-text">
+      <%= t(".if_your_response", date: date_due(@validation_request)) %>
+    </div>
+  <% end %>
   <%= render "shared/planning_guides_link" %>
 <% end %>
 <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">


### PR DESCRIPTION
## What

Hide return and refund information for post validation additional document request.

## Story card

https://trello.com/c/LQG1atOK/735-enable-amendment-requests-for-new-documents-that-can-be-actioned-after-validation-2

See also https://github.com/unboxed/bops/pull/694