### PR TITLE
Forgery protection origin check

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -36,5 +36,7 @@ module BopsApplicants
     config.generators.system_tests = nil
 
     config.autoload_paths += %W[#{config.root}/lib]
+
+    config.action_controller.forgery_protection_origin_check = false
   end
 end

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -38,7 +38,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Include generic and useful information about system operation, but avoid logging too much
   # information to avoid inadvertent exposure of personally identifiable information (PII).


### PR DESCRIPTION
1) Disable origin checking with forgery_protection_origin_check = false
2) Force all access to the app over SSL

- With adding the new public facing url i.e. https://planningapplications.lambeth.gov.uk/ we were getting an 'ActionController::InvalidAuthenticityToken: HTTP Origin header (https://planningapplications.lambeth.gov.uk/) didn't match request.base_url (https://lambeth.bops-applicants.services/)' error

This is originated from https://github.com/rails/rails/blob/dc1242fd5a4d91e63846ab552a07e19ebf8716ac/actionpack/lib/action_controller/metal/request_forgery_protection.rb#L455-L463

Not we use an x-forwarded-host header on CloudFront which causes this issue


TODO: Use `config.hosts` to make the above solution a bit more robust