### PR TITLE
Render application reference on index page

### DIFF
--- a/app/helpers/validation_requests_helper.rb
+++ b/app/helpers/validation_requests_helper.rb
@@ -5,10 +5,6 @@ module ValidationRequestsHelper
     "#{planning_application['site']['address_1']}, #{planning_application['site']['town']}, #{planning_application['site']['postcode']}"
   end
 
-  def reference(planning_application)
-    planning_application["id"].to_s.rjust(8, "0")
-  end
-
   def date_received(planning_application)
     planning_application["created_at"].to_date.strftime("%e %B %Y")
   end

--- a/app/views/validation_requests/index.html.erb
+++ b/app/views/validation_requests/index.html.erb
@@ -7,7 +7,7 @@
       <strong><%= t(".date_received") %></strong>
       <%= date_received(@planning_application) %><br>
       <strong><%= t(".application_number") %></strong>
-      <%= reference(@planning_application) %><br>
+      <%= @planning_application["reference"] %><br>
       <br>
     </p>
     <p class="govuk-body"><%= t(".the_case_officer") %></p>

--- a/spec/fixtures/test_planning_application.json
+++ b/spec/fixtures/test_planning_application.json
@@ -15,6 +15,7 @@
   "invalidated_at": "2021-04-23T10:15:52.855Z",
   "in_assessment_at": null,
   "payment_reference": "PAY1",
+  "reference": "22-00100-LDCP",
   "returned_at": null,
   "started_at": null,
   "status": "invalidated",

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -17,6 +17,10 @@ RSpec.describe "landing page", type: :system do
     )
   end
 
+  it "renders the application reference" do
+    expect(page).to have_content("Application number: 22-00100-LDCP")
+  end
+
   context "within phase-banner" do
     it "lets the user navigate to feedback" do
       within(".govuk-phase-banner") { expect(page).to have_link("feedback") }

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe "Change requests", type: :system do
 
     expect(page).to have_content("11 Mel Gardens, London, SE16 3RQ")
     expect(page).to have_content("Date received: 23 April 2021")
-    expect(page).to have_content("00000028")
+    expect(page).to have_content("Application number: 22-00100-LDCP")
   end
 
   it "displays the description of the change request on the change request page" do


### PR DESCRIPTION
### What

- Render application reference on index page instead of 'reference' derived from id.

### Why

https://trello.com/c/AaKA7J8W/1145-bops-applicants-not-using-updated-case-references

### Screenshot

<img width="65%" alt="Screenshot 2022-09-13 at 11 57 27" src="https://user-images.githubusercontent.com/25392162/189884267-c07a7055-cfdb-4700-9e2e-48c4e1dd01ba.png">
