### PR TITLE
Align rubocop configuration with BOPS

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,35 +1,84 @@
-inherit_gem:
-  rubocop-govuk:
-    - config/default.yml
-    - config/rails.yml
-    - config/rspec.yml
-
+---
 inherit_mode:
   merge:
     - Exclude
 
-Lint/MissingSuper:
-  Exclude:
-    - app/components/**/*.rb
+require:
+  - rubocop-performance
+  - rubocop-rails
+  - rubocop-rspec
 
-Rails:
-  Exclude:
-    - "lib/package_builder.rb"
+AllCops:
+  TargetRubyVersion: 3.2.0
+  NewCops: enable
 
-RSpec/ContextWording:
+Style/StringLiterals:
+  EnforcedStyle: double_quotes
+
+Style/Documentation:
   Enabled: false
 
-RSpec/LetSetup:
+# be a bit kinder with our metrics
+Metrics/BlockLength:
+  Max: 100
+  Exclude:
+    - spec/**/*
+    - config/routes.rb
+
+Metrics/MethodLength:
+  Max: 20
+
+Layout/LineLength:
+  Exclude:
+    - spec/**/*
+    - app/services/apis/bops/client.rb
+
+Naming/VariableNumber:
+  Exclude:
+    - spec/**/*
+
+# we tend to use update_all in migrations
+Rails/SkipsModelValidations:
+  Exclude:
+    - db/migrate/*.rb
+
+# Rspec
+RSpec/MultipleExpectations:
   Enabled: false
+
+RSpec/ExampleLength:
+  Enabled: false
+
+RSpec/NestedGroups:
+  Max: 5
 
 RSpec/InstanceVariable:
   Enabled: false
 
-Naming/VariableNumber:
+RSpec/MultipleMemoizedHelpers:
   Enabled: false
 
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/ContextWording:
+  Enabled: false
+  Prefixes:
+    - as
+    - before
+    - when
+    - with
+    - without
+
+RSpec/MessageSpies:
+  Enabled: false
+
+RSpec/StubbedMock:
+  Enabled: false
+
 RSpec/VerifiedDoubles:
   Enabled: false
+
+Lint/MissingSuper:
+  Exclude:
+    - app/components/**/*.rb

--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
@@ -31,7 +33,9 @@ group :development, :test do
   gem "pry-byebug"
   gem "rspec-rails", "~> 5.0.0"
   gem "rubocop", require: false
-  gem "rubocop-govuk", require: false
+  gem "rubocop-performance", require: false
+  gem "rubocop-rails", require: false
+  gem "rubocop-rspec", require: false
   gem "webdrivers"
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -247,18 +247,13 @@ GEM
       unicode-display_width (>= 1.4.0, < 3.0)
     rubocop-ast (1.18.0)
       parser (>= 3.1.1.0)
-    rubocop-govuk (4.5.0)
-      rubocop (= 1.30.1)
-      rubocop-ast (= 1.18.0)
-      rubocop-rails (= 2.14.2)
-      rubocop-rake (= 0.6.0)
-      rubocop-rspec (= 2.11.1)
+    rubocop-performance (1.16.0)
+      rubocop (>= 1.7.0, < 2.0)
+      rubocop-ast (>= 0.4.0)
     rubocop-rails (2.14.2)
       activesupport (>= 4.2.0)
       rack (>= 1.1)
       rubocop (>= 1.7.0, < 2.0)
-    rubocop-rake (0.6.0)
-      rubocop (~> 1.0)
     rubocop-rspec (2.11.1)
       rubocop (~> 1.19)
     ruby-progressbar (1.11.0)
@@ -331,7 +326,9 @@ DEPENDENCIES
   rails_autolink
   rspec-rails (~> 5.0.0)
   rubocop
-  rubocop-govuk
+  rubocop-performance
+  rubocop-rails
+  rubocop-rspec
   spring
   sprockets-rails
   turbolinks (~> 5)

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Add your own tasks in files placed in lib/tasks ending in .rake,
 # for example lib/tasks/capistrano.rake, and they will automatically be available to Rake.
 

--- a/app/components/formatted_content_component.rb
+++ b/app/components/formatted_content_component.rb
@@ -12,7 +12,7 @@ class FormattedContentComponent < ViewComponent::Base
     sanitize(simple_format_content, attributes: allowed_attributes)
   end
 
-private
+  private
 
   attr_reader :text, :classname
 

--- a/app/controllers/additional_document_validation_requests_controller.rb
+++ b/app/controllers/additional_document_validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class AdditionalDocumentValidationRequestsController < ValidationRequestsController
   before_action :set_validation_request
 
@@ -27,7 +29,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
 
     respond_to do |format|
       if @additional_document_validation_request.update
-        flash[:notice] = "Your response was updated successfully"
+        flash[:notice] = t("shared.response_updated.success")
         format.html { validation_requests_redirect_url }
       else
         flash[:error] = error_message(@additional_document_validation_request)
@@ -36,7 +38,7 @@ class AdditionalDocumentValidationRequestsController < ValidationRequestsControl
     end
   end
 
-private
+  private
 
   def additional_document_validation_request_params
     params.require(:additional_document_validation_request).permit(files: [])

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ApplicationController < ActionController::Base
   helper_method :current_local_authority
 
@@ -9,7 +11,7 @@ class ApplicationController < ActionController::Base
     request.subdomains.first
   end
 
-private
+  private
 
   def set_current_local_authority
     Current.local_authority = current_local_authority

--- a/app/controllers/concerns/api/error_handler.rb
+++ b/app/controllers/concerns/api/error_handler.rb
@@ -1,55 +1,57 @@
 # frozen_string_literal: true
 
-module Api::ErrorHandler
-  extend ActiveSupport::Concern
-  include HttpStatusCodes
+module Api
+  module ErrorHandler
+    extend ActiveSupport::Concern
+    include HttpStatusCodes
 
-  included do
-    rescue_from Request::RecordNotFoundError, with: :format_error
-    rescue_from Request::BadRequestError, with: :format_error
-    rescue_from Request::UnauthorizedError, with: :format_error
-    rescue_from Request::ForbiddenError, with: :format_error
-    rescue_from Request::TimeoutError, with: :format_error
-    rescue_from Request::ApiError, with: :format_error
+    included do
+      rescue_from Request::RecordNotFoundError, with: :format_error
+      rescue_from Request::BadRequestError, with: :format_error
+      rescue_from Request::UnauthorizedError, with: :format_error
+      rescue_from Request::ForbiddenError, with: :format_error
+      rescue_from Request::TimeoutError, with: :format_error
+      rescue_from Request::ApiError, with: :format_error
 
-  private
+      private
 
-    def format_error(error)
-      error_hash = instance_eval(error.message)
+      def format_error(error) # rubocop:disable Metrics/AbcSize, Metrics/MethodLength
+        error_hash = instance_eval(error.message)
 
-      response = error_hash[:response]
-      message = response["message"] || response
-      status = error_hash[:status].to_s || API_ERROR.to_s
-      http_method = error_hash[:http_method].to_s
+        response = error_hash[:response]
+        message = response["message"] || response
+        status = error_hash[:status].to_s || API_ERROR.to_s
+        http_method = error_hash[:http_method].to_s
 
-      respond_to do |format|
-        format.json do
-          render json: {
-            errors: [
-              {
-                title: message,
-                status:,
-              },
-            ],
-          }, status:
-        end
+        respond_to do |format|
+          format.json do
+            render json: {
+              errors: [
+                {
+                  title: message,
+                  status:
+                }
+              ]
+            }, status:
+          end
 
-        format.html do
-          if render_not_found?(status, http_method)
-            render_not_found
-          else
-            flash[:alert] = "Oops. Your request failed with error status: #{status} and message: #{message}"
+          format.html do
+            if render_not_found?(status, http_method)
+              render_not_found
+            else
+              flash[:alert] = "Oops. Your request failed with error status: #{status} and message: #{message}"
 
-            validation_requests_redirect_url
+              validation_requests_redirect_url
+            end
           end
         end
       end
-    end
 
-    def render_not_found?(status, http_method)
-      return true if status == NOT_FOUND.to_s
+      def render_not_found?(status, http_method)
+        return true if status == NOT_FOUND.to_s
 
-      http_method == "get" && (status == UNAUTHORIZED.to_s || status == FORBIDDEN.to_s)
+        http_method == "get" && (status == UNAUTHORIZED.to_s || status == FORBIDDEN.to_s)
+      end
     end
   end
 end

--- a/app/controllers/description_change_validation_requests_controller.rb
+++ b/app/controllers/description_change_validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class DescriptionChangeValidationRequestsController < ValidationRequestsController
   before_action :set_validation_request
 
@@ -27,7 +29,7 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
 
     respond_to do |format|
       if @description_change_validation_request.update
-        flash[:notice] = "Your response was updated successfully"
+        flash[:notice] = t("shared.response_updated.success")
         format.html { validation_requests_redirect_url }
       else
         flash[:error] = error_message(@description_change_validation_request)
@@ -36,7 +38,7 @@ class DescriptionChangeValidationRequestsController < ValidationRequestsControll
     end
   end
 
-private
+  private
 
   def description_change_validation_request_params
     params.require(:description_change_validation_request).permit(:approved, :rejection_reason)

--- a/app/controllers/other_change_validation_requests_controller.rb
+++ b/app/controllers/other_change_validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class OtherChangeValidationRequestsController < ValidationRequestsController
   before_action :set_validation_request
 
@@ -27,7 +29,7 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
 
     respond_to do |format|
       if @other_change_validation_request.update
-        flash[:notice] = "Your response was updated successfully"
+        flash[:notice] = t("shared.response_updated.success")
         format.html { validation_requests_redirect_url }
       else
         flash[:error] = error_message(@other_change_validation_request)
@@ -36,7 +38,7 @@ class OtherChangeValidationRequestsController < ValidationRequestsController
     end
   end
 
-private
+  private
 
   def other_change_validation_request_params
     params.require(:other_change_validation_request).permit(:response)

--- a/app/controllers/pages_controller.rb
+++ b/app/controllers/pages_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class PagesController < ApplicationController
   def accessibility; end
 end

--- a/app/controllers/red_line_boundary_change_validation_requests_controller.rb
+++ b/app/controllers/red_line_boundary_change_validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsController
   before_action :set_validation_request, :set_planning_application
 
@@ -23,11 +25,12 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
   end
 
   def update
-    @red_line_boundary_change_validation_request = build_validation_request(red_line_boundary_change_validation_request_params)
+    @red_line_boundary_change_validation_request =
+      build_validation_request(red_line_boundary_change_validation_request_params)
 
     respond_to do |format|
       if @red_line_boundary_change_validation_request.update
-        flash[:notice] = "Your response was updated successfully"
+        flash[:notice] = t("shared.response_updated.success")
         format.html { validation_requests_redirect_url }
       else
         flash[:error] = error_message(@red_line_boundary_change_validation_request)
@@ -36,7 +39,7 @@ class RedLineBoundaryChangeValidationRequestsController < ValidationRequestsCont
     end
   end
 
-private
+  private
 
   def red_line_boundary_change_validation_request_params
     params.require(:red_line_boundary_change_validation_request).permit(:approved, :rejection_reason)

--- a/app/controllers/replacement_document_validation_requests_controller.rb
+++ b/app/controllers/replacement_document_validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ReplacementDocumentValidationRequestsController < ValidationRequestsController
   before_action :set_validation_request
 
@@ -27,7 +29,7 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
 
     respond_to do |format|
       if @replacement_document_validation_request.update
-        flash[:notice] = "Your response was updated successfully"
+        flash[:notice] = t("shared.response_updated.success")
         format.html { validation_requests_redirect_url }
       else
         flash[:error] = error_message(@replacement_document_validation_request)
@@ -36,7 +38,7 @@ class ReplacementDocumentValidationRequestsController < ValidationRequestsContro
     end
   end
 
-private
+  private
 
   def replacement_document_validation_request_params
     params.require(:replacement_document_validation_request).permit(:file)

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class ValidationRequestsController < ApplicationController
   include Api::ErrorHandler
 
@@ -9,7 +11,7 @@ class ValidationRequestsController < ApplicationController
     end
   end
 
-private
+  private
 
   def set_validation_requests
     @validation_requests = Bops::ValidationRequest.find_all(params[:planning_application_id], params[:change_access_id])
@@ -36,7 +38,7 @@ private
   def validation_requests_redirect_url
     redirect_to validation_requests_path(
       planning_application_id: params[:planning_application_id],
-      change_access_id: params[:change_access_id],
+      change_access_id: params[:change_access_id]
     )
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,9 +1,11 @@
+# frozen_string_literal: true
+
 module ApplicationHelper
   def formatted_phone_number
     number_to_phone(
       contact_details[:phone_number],
       delimiter: " ",
-      pattern: /(\d{5})(\d{3})(\d{3})$/,
+      pattern: /(\d{5})(\d{3})(\d{3})$/
     )
   end
 

--- a/app/helpers/validation_requests_helper.rb
+++ b/app/helpers/validation_requests_helper.rb
@@ -2,7 +2,11 @@
 
 module ValidationRequestsHelper
   def full_address(planning_application)
-    "#{planning_application['site']['address_1']}, #{planning_application['site']['town']}, #{planning_application['site']['postcode']}"
+    [
+      planning_application["site"]["address_1"],
+      planning_application["site"]["town"],
+      planning_application["site"]["postcode"]
+    ].join(", ")
   end
 
   def date_received(planning_application)
@@ -18,7 +22,11 @@ module ValidationRequestsHelper
   end
 
   def flattened_validation_requests(validation_requests)
-    validation_requests["data"]["additional_document_validation_requests"] + validation_requests["data"]["description_change_validation_requests"] + validation_requests["data"]["replacement_document_validation_requests"] + validation_requests["data"]["other_change_validation_requests"] + validation_requests["data"]["red_line_boundary_change_validation_requests"]
+    validation_requests["data"]["additional_document_validation_requests"] +
+      validation_requests["data"]["description_change_validation_requests"] +
+      validation_requests["data"]["replacement_document_validation_requests"] +
+      validation_requests["data"]["other_change_validation_requests"] +
+      validation_requests["data"]["red_line_boundary_change_validation_requests"]
   end
 
   def counter_change_requests_order(validation_request)
@@ -30,7 +38,11 @@ module ValidationRequestsHelper
   end
 
   def ordered_validation_requests
-    %w[description_change_validation_requests replacement_document_validation_requests additional_document_validation_requests red_line_boundary_change_validation_requests other_change_validation_requests]
+    %w[description_change_validation_requests
+       replacement_document_validation_requests
+       additional_document_validation_requests
+       red_line_boundary_change_validation_requests
+       other_change_validation_requests]
   end
 
   def count_total_requests(validation_requests, name)

--- a/app/models/bops/description_change_validation_request.rb
+++ b/app/models/bops/description_change_validation_request.rb
@@ -19,7 +19,8 @@ module Bops
       end
 
       def reject(id, planning_application_id, change_access_id, rejection_reason)
-        Apis::Bops::Client.patch_rejected_description_change(id, planning_application_id, change_access_id, rejection_reason)
+        Apis::Bops::Client.patch_rejected_description_change(id, planning_application_id, change_access_id,
+                                                             rejection_reason)
       end
     end
 
@@ -35,7 +36,7 @@ module Bops
       end
     end
 
-  private
+    private
 
     def not_approved?
       approved == "no"

--- a/app/models/bops/red_line_boundary_change_validation_request.rb
+++ b/app/models/bops/red_line_boundary_change_validation_request.rb
@@ -11,7 +11,8 @@ module Bops
 
     class << self
       def find(id, planning_application_id, change_access_id)
-        Apis::Bops::Client.get_red_line_boundary_change_validation_request(id, planning_application_id, change_access_id)
+        Apis::Bops::Client.get_red_line_boundary_change_validation_request(id, planning_application_id,
+                                                                           change_access_id)
       end
 
       def approve(id, planning_application_id, change_access_id)
@@ -19,7 +20,8 @@ module Bops
       end
 
       def reject(id, planning_application_id, change_access_id, rejection_reason)
-        Apis::Bops::Client.patch_rejected_red_line_boundary_change(id, planning_application_id, change_access_id, rejection_reason)
+        Apis::Bops::Client.patch_rejected_red_line_boundary_change(id, planning_application_id, change_access_id,
+                                                                   rejection_reason)
       end
     end
 
@@ -35,7 +37,7 @@ module Bops
       end
     end
 
-  private
+    private
 
     def not_approved?
       approved == "no"

--- a/app/services/apis/bops/client.rb
+++ b/app/services/apis/bops/client.rb
@@ -2,13 +2,13 @@
 
 module Apis
   module Bops
-    class Client
+    class Client # rubocop:disable Metrics/ClassLength
       class << self
         # Planning application
         def get_planning_application(planning_application_id)
           request(
             http_method: :get,
-            endpoint: planning_application_id.to_s,
+            endpoint: planning_application_id.to_s
           )
         end
 
@@ -16,7 +16,7 @@ module Apis
         def get_validation_requests(planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/validation_requests?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/validation_requests?change_access_id=#{change_access_id}"
           )
         end
 
@@ -24,7 +24,7 @@ module Apis
         def get_description_change_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
           )
         end
 
@@ -33,10 +33,10 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "data": {
-                "approved": true,
-              },
-            }.to_json,
+              data: {
+                approved: true
+              }
+            }.to_json
           )
         end
 
@@ -45,11 +45,11 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "data": {
-                "approved": false,
-                "rejection_reason": rejection_reason,
-              },
-            }.to_json,
+              data: {
+                approved: false,
+                rejection_reason:
+              }
+            }.to_json
           )
         end
 
@@ -57,7 +57,7 @@ module Apis
         def get_other_change_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
           )
         end
 
@@ -66,10 +66,10 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "data": {
-                "response": response,
-              },
-            }.to_json,
+              data: {
+                response:
+              }
+            }.to_json
           )
         end
 
@@ -77,7 +77,7 @@ module Apis
         def get_red_line_boundary_change_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
           )
         end
 
@@ -87,9 +87,9 @@ module Apis
             endpoint: "#{planning_application_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
               data: {
-                "approved": true,
-              },
-            }.to_json,
+                approved: true
+              }
+            }.to_json
           )
         end
 
@@ -98,11 +98,11 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "data": {
-                "approved": false,
-                "rejection_reason": rejection_reason,
-              },
-            }.to_json,
+              data: {
+                approved: false,
+                rejection_reason:
+              }
+            }.to_json
           )
         end
 
@@ -110,7 +110,7 @@ module Apis
         def get_additional_document_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
           )
         end
 
@@ -119,9 +119,9 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "files": files,
+              files:
             },
-            upload_file: true,
+            upload_file: true
           )
         end
 
@@ -129,7 +129,7 @@ module Apis
         def get_replacement_document_validation_request(id, planning_application_id, change_access_id)
           request(
             http_method: :get,
-            endpoint: "#{planning_application_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+            endpoint: "#{planning_application_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
           )
         end
 
@@ -138,13 +138,13 @@ module Apis
             http_method: :patch,
             endpoint: "#{planning_application_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
             params: {
-              "file": file,
+              file:
             },
-            upload_file: true,
+            upload_file: true
           )
         end
 
-      private
+        private
 
         def request(http_method:, endpoint:, params: {}, upload_file: false)
           Request.new(http_method, endpoint, params, upload_file).call

--- a/app/services/http_client.rb
+++ b/app/services/http_client.rb
@@ -4,7 +4,7 @@ class HttpClient
   attr_reader :api_base_url
 
   def initialize
-    @api_base_url = "#{ENV['PROTOCOL']}://#{api_base}/planning_applications/"
+    @api_base_url = "#{ENV.fetch('PROTOCOL', nil)}://#{api_base}/planning_applications/"
   end
 
   def connection
@@ -23,12 +23,12 @@ class HttpClient
   def http_party(endpoint, params)
     HTTParty.patch(
       "#{api_base_url}#{endpoint}",
-      headers: { "Authorization": authorization_header },
-      body: file_params_body(params),
+      headers: { Authorization: authorization_header },
+      body: file_params_body(params)
     )
   end
 
-private
+  private
 
   def file_params_body(params)
     {}.tap do |hash|
@@ -38,10 +38,10 @@ private
   end
 
   def api_base
-    "#{Current.local_authority}.#{ENV['API_HOST'] || 'bops-care.link'}/api/v1"
+    "#{Current.local_authority}.#{ENV.fetch('API_HOST', 'bops-care.link')}/api/v1"
   end
 
   def authorization_header
-    "Bearer #{ENV['API_BEARER']}"
+    "Bearer #{ENV.fetch('API_BEARER', nil)}"
   end
 end

--- a/app/services/request.rb
+++ b/app/services/request.rb
@@ -48,7 +48,7 @@ class Request
     end
   end
 
-private
+  private
 
   attr_reader :connection, :http_method, :params, :upload_file
 
@@ -56,7 +56,7 @@ private
     { response:, status:, http_method: }
   end
 
-  def get_response_and_status
+  def get_response_and_status # rubocop:disable Metrics/AbcSize, Naming/AccessorMethodName
     raise RecordNotFoundError, errors("Not found", NOT_FOUND) if endpoint.blank?
 
     if upload_file

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is used by Rack-based servers to start the application.
 
 require_relative "config/environment"

--- a/config/application.rb
+++ b/config/application.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require_relative "boot"
 
 require "rails"

--- a/config/boot.rb
+++ b/config/boot.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 ENV["BUNDLE_GEMFILE"] ||= File.expand_path("../Gemfile", __dir__)
 
 require "bundler/setup" # Set up gems listed in the Gemfile.

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Load the Rails application.
 require_relative "application"
 

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
@@ -22,7 +24,7 @@ Rails.application.configure do
 
     config.cache_store = :memory_store
     config.public_file_server.headers = {
-      "Cache-Control" => "public, max-age=#{2.days.to_i}",
+      "Cache-Control" => "public, max-age=#{2.days.to_i}"
     }
   else
     config.action_controller.perform_caching = false

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "active_support/core_ext/integer/time"
 
 # The test environment is used exclusively to run your application's
@@ -19,7 +21,7 @@ Rails.application.configure do
   # Configure public file server for tests with Cache-Control for performance.
   config.public_file_server.enabled = true
   config.public_file_server.headers = {
-    "Cache-Control" => "public, max-age=#{1.hour.to_i}",
+    "Cache-Control" => "public, max-age=#{1.hour.to_i}"
   }
 
   # Show full error reports and disable caching.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Version of your assets, change this if you want to expire all your assets.

--- a/config/initializers/backtrace_silencers.rb
+++ b/config/initializers/backtrace_silencers.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Define an application-wide content security policy

--- a/config/initializers/cookies_serializer.rb
+++ b/config/initializers/cookies_serializer.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Specify a serializer for the signed and encrypted cookie jars.

--- a/config/initializers/filter_parameter_logging.rb
+++ b/config/initializers/filter_parameter_logging.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Configure sensitive parameters which will be filtered from the log file.

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format. Inflections

--- a/config/initializers/mime_types.rb
+++ b/config/initializers/mime_types.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/config/initializers/permissions_policy.rb
+++ b/config/initializers/permissions_policy.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 # Define an application-wide HTTP permissions policy. For further
 # information see https://developers.google.com/web/updates/2018/06/feature-policy
 #

--- a/config/initializers/wrap_parameters.rb
+++ b/config/initializers/wrap_parameters.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # This file contains settings for ActionController::ParamsWrapper which

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -61,8 +61,7 @@ en:
       preparation_of_this: Preparation of this accessibility statement
       reporting_accessibility_problems: Reporting accessibility problems with this website
       technical_information_about: "Technical information about this website's accessibility"
-      the_equality_and: "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018
-(the 'accessibility regulations'). If you're not happy with how we respond to your complaint, %{link}."
+      the_equality_and: "The Equality and Human Rights Commission (EHRC) is responsible for enforcing the Public Sector Bodies (Websites and Mobile Applications) (No. 2) Accessibility Regulations 2018 (the 'accessibility regulations'). If you're not happy with how we respond to your complaint, %{link}."
       the_equality_and_link: contact the Equality Advisory and Support Service (EASS)
       this_accessibility_statement: This accessibility statement applies to publicly available pages of the Back-office planning system.
       this_statement_was: This statement was prepared on 1st June 2022. This website was last tested on 12th May 2022. The test was carried out by the Digital Accessibility Centre.
@@ -135,6 +134,10 @@ en:
       inclusion: "%{attribute} is not included in the list"
       invalid: "%{attribute} is invalid"
       required: "%{attribute} must exist"
+
+  shared:
+    response_updated:
+      success: "Your response was updated successfully"
 
   activemodel:
     errors:

--- a/config/puma.rb
+++ b/config/puma.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # Puma can serve each request in a thread from an internal thread pool.
 # The `threads` method setting takes two numbers: a minimum and maximum.
 # Any libraries that use thread pools should be configured to match
@@ -19,10 +21,10 @@ port ENV.fetch("PORT", 3000)
 
 # Specifies the `environment` that Puma will run in.
 #
-environment ENV.fetch("RAILS_ENV") { "development" }
+environment ENV.fetch("RAILS_ENV", "development")
 
 # Specifies the `pidfile` that Puma will use.
-pidfile ENV.fetch("PIDFILE") { "tmp/pids/server.pid" }
+pidfile ENV.fetch("PIDFILE", "tmp/pids/server.pid")
 
 # Specifies the number of `workers` to boot in clustered mode.
 # Workers are forked web server processes. If using threads and workers together

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see https://guides.rubyonrails.org/routing.html
 

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -2,7 +2,5 @@
 
 desc "Run brakeman checks and exit with an error code if there are any issues"
 task brakeman: :environment do
-  unless system "brakeman -z --no-pager"
-    exit 1
-  end
+  exit 1 unless system "brakeman -z --no-pager"
 end

--- a/lib/tasks/bundle_audit.rake
+++ b/lib/tasks/bundle_audit.rake
@@ -2,7 +2,5 @@
 
 desc "Audit bundle for any known vulnerabilities"
 task bundle_audit: :environment do
-  unless system "bundle-audit check --update"
-    exit 1
-  end
+  exit 1 unless system "bundle-audit check --update"
 end

--- a/lib/tasks/rubocop.rake
+++ b/lib/tasks/rubocop.rake
@@ -2,7 +2,5 @@
 
 desc "Run the rubocop static code analyzer"
 task rubocop: :environment do
-  unless system "rubocop"
-    exit 1
-  end
+  exit 1 unless system "rubocop"
 end

--- a/spec/components/formatted_content_component_spec.rb
+++ b/spec/components/formatted_content_component_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe FormattedContentComponent, type: :component do
       expect(page).to have_css "p[class='govuk-body']", text: "content including link https://www.bops.co.uk/"
 
       expect(component.auto_link_and_simple_format).to eq(
-        "<p class=\"govuk-body\">content including link <a target=\"_blank\" href=\"https://www.bops.co.uk/\">https://www.bops.co.uk/</a></p>",
+        "<p class=\"govuk-body\">content including link <a target=\"_blank\" href=\"https://www.bops.co.uk/\">https://www.bops.co.uk/</a></p>"
       )
     end
   end
@@ -38,7 +38,7 @@ RSpec.describe FormattedContentComponent, type: :component do
       expect(page).to have_css "p[class='govuk-body']", text: "content including html Bops validation"
 
       expect(component.auto_link_and_simple_format).to eq(
-        "<p class=\"govuk-body\">content including html <a href=\"https://bops.com/validate\" target=\"_blank\">Bops validation</a></p>",
+        "<p class=\"govuk-body\">content including html <a href=\"https://bops.com/validate\" target=\"_blank\">Bops validation</a></p>"
       )
     end
   end
@@ -50,7 +50,7 @@ RSpec.describe FormattedContentComponent, type: :component do
 
     it "sanitizes it" do
       expect(component.auto_link_and_simple_format).to eq(
-        "<p class=\"govuk-body\">content including <a target=\"_blank\" href=\"http://www.bops.com\">http://www.bops.com</a> </p>",
+        "<p class=\"govuk-body\">content including <a target=\"_blank\" href=\"http://www.bops.com\">http://www.bops.com</a> </p>"
       )
     end
   end

--- a/spec/helpers/validation_requests_helper_spec.rb
+++ b/spec/helpers/validation_requests_helper_spec.rb
@@ -6,137 +6,137 @@ RSpec.describe ValidationRequestsHelper, type: :helper do
   describe "latest_request_due" do
     it "finds the latest data if it is in description_change_validation_requests" do
       expect(latest_request_due({
-        "data" => {
-          "additional_document_validation_requests" => [
-            { "response_due" => "2021-05-29" },
-            { "response_due" => "2021-05-28" },
-          ],
-          "description_change_validation_requests" => [
-            { "response_due" => "2021-06-10" },
-            { "response_due" => "2021-06-12" },
-          ],
-          "replacement_document_validation_requests" => [
-            { "response_due" => "2021-06-11" },
-            { "response_due" => "2021-06-05" },
-          ],
-          "red_line_boundary_change_validation_requests" => [
-            { "response_due" => "2021-06-04" },
-            { "response_due" => "2021-06-02" },
-          ],
-          "other_change_validation_requests" => [
-            { "response_due" => "2021-06-01" },
-            { "response_due" => "2021-06-02" },
-          ],
-        },
-      })).to eq({ "response_due" => "2021-06-12" })
+                                  "data" => {
+                                    "additional_document_validation_requests" => [
+                                      { "response_due" => "2021-05-29" },
+                                      { "response_due" => "2021-05-28" }
+                                    ],
+                                    "description_change_validation_requests" => [
+                                      { "response_due" => "2021-06-10" },
+                                      { "response_due" => "2021-06-12" }
+                                    ],
+                                    "replacement_document_validation_requests" => [
+                                      { "response_due" => "2021-06-11" },
+                                      { "response_due" => "2021-06-05" }
+                                    ],
+                                    "red_line_boundary_change_validation_requests" => [
+                                      { "response_due" => "2021-06-04" },
+                                      { "response_due" => "2021-06-02" }
+                                    ],
+                                    "other_change_validation_requests" => [
+                                      { "response_due" => "2021-06-01" },
+                                      { "response_due" => "2021-06-02" }
+                                    ]
+                                  }
+                                })).to eq({ "response_due" => "2021-06-12" })
     end
 
     it "finds the latest date if it is in replacement_document_validation_requests" do
       expect(latest_request_due({
-        "data" => {
-          "additional_document_validation_requests" => [
-            { "response_due" => "2021-05-29" },
-            { "response_due" => "2021-05-28" },
-          ],
-          "description_change_validation_requests" => [
-            { "response_due" => "2021-06-10" },
-            { "response_due" => "2021-06-04" },
-          ],
-          "replacement_document_validation_requests" => [
-            { "response_due" => "2021-06-11" },
-            { "response_due" => "2021-06-03" },
-          ],
-          "red_line_boundary_change_validation_requests" => [
-            { "response_due" => "2021-06-04" },
-            { "response_due" => "2021-06-02" },
-          ],
-          "other_change_validation_requests" => [
-            { "response_due" => "2021-05-29" },
-            { "response_due" => "2021-05-30" },
-          ],
-        },
-      })).to eq({ "response_due" => "2021-06-11" })
+                                  "data" => {
+                                    "additional_document_validation_requests" => [
+                                      { "response_due" => "2021-05-29" },
+                                      { "response_due" => "2021-05-28" }
+                                    ],
+                                    "description_change_validation_requests" => [
+                                      { "response_due" => "2021-06-10" },
+                                      { "response_due" => "2021-06-04" }
+                                    ],
+                                    "replacement_document_validation_requests" => [
+                                      { "response_due" => "2021-06-11" },
+                                      { "response_due" => "2021-06-03" }
+                                    ],
+                                    "red_line_boundary_change_validation_requests" => [
+                                      { "response_due" => "2021-06-04" },
+                                      { "response_due" => "2021-06-02" }
+                                    ],
+                                    "other_change_validation_requests" => [
+                                      { "response_due" => "2021-05-29" },
+                                      { "response_due" => "2021-05-30" }
+                                    ]
+                                  }
+                                })).to eq({ "response_due" => "2021-06-11" })
     end
 
     it "finds the latest date if it is in red_line_boundary_change_validation_requests" do
       expect(latest_request_due({
-        "data" => {
-          "additional_document_validation_requests" => [
-            { "response_due" => "2021-05-29" },
-            { "response_due" => "2021-05-28" },
-          ],
-          "description_change_validation_requests" => [
-            { "response_due" => "2021-06-10" },
-            { "response_due" => "2021-06-04" },
-          ],
-          "replacement_document_validation_requests" => [
-            { "response_due" => "2021-06-11" },
-            { "response_due" => "2021-06-03" },
-          ],
-          "red_line_boundary_change_validation_requests" => [
-            { "response_due" => "2021-07-12" },
-            { "response_due" => "2021-06-02" },
-          ],
-          "other_change_validation_requests" => [
-            { "response_due" => "2021-06-29" },
-            { "response_due" => "2021-06-30" },
-          ],
-        },
-      })).to eq({ "response_due" => "2021-07-12" })
+                                  "data" => {
+                                    "additional_document_validation_requests" => [
+                                      { "response_due" => "2021-05-29" },
+                                      { "response_due" => "2021-05-28" }
+                                    ],
+                                    "description_change_validation_requests" => [
+                                      { "response_due" => "2021-06-10" },
+                                      { "response_due" => "2021-06-04" }
+                                    ],
+                                    "replacement_document_validation_requests" => [
+                                      { "response_due" => "2021-06-11" },
+                                      { "response_due" => "2021-06-03" }
+                                    ],
+                                    "red_line_boundary_change_validation_requests" => [
+                                      { "response_due" => "2021-07-12" },
+                                      { "response_due" => "2021-06-02" }
+                                    ],
+                                    "other_change_validation_requests" => [
+                                      { "response_due" => "2021-06-29" },
+                                      { "response_due" => "2021-06-30" }
+                                    ]
+                                  }
+                                })).to eq({ "response_due" => "2021-07-12" })
     end
 
     it "finds the latest date if it is in other_change_validation_requests" do
       expect(latest_request_due({
-        "data" => {
-          "additional_document_validation_requests" => [
-            { "response_due" => "2021-05-29" },
-            { "response_due" => "2021-05-28" },
-          ],
-          "description_change_validation_requests" => [
-            { "response_due" => "2021-06-10" },
-            { "response_due" => "2021-06-04" },
-          ],
-          "replacement_document_validation_requests" => [
-            { "response_due" => "2021-06-11" },
-            { "response_due" => "2021-06-03" },
-          ],
-          "red_line_boundary_change_validation_requests" => [
-            { "response_due" => "2021-04-12" },
-            { "response_due" => "2021-06-02" },
-          ],
-          "other_change_validation_requests" => [
-            { "response_due" => "2021-06-29" },
-            { "response_due" => "2021-06-30" },
-          ],
-        },
-      })).to eq({ "response_due" => "2021-06-30" })
+                                  "data" => {
+                                    "additional_document_validation_requests" => [
+                                      { "response_due" => "2021-05-29" },
+                                      { "response_due" => "2021-05-28" }
+                                    ],
+                                    "description_change_validation_requests" => [
+                                      { "response_due" => "2021-06-10" },
+                                      { "response_due" => "2021-06-04" }
+                                    ],
+                                    "replacement_document_validation_requests" => [
+                                      { "response_due" => "2021-06-11" },
+                                      { "response_due" => "2021-06-03" }
+                                    ],
+                                    "red_line_boundary_change_validation_requests" => [
+                                      { "response_due" => "2021-04-12" },
+                                      { "response_due" => "2021-06-02" }
+                                    ],
+                                    "other_change_validation_requests" => [
+                                      { "response_due" => "2021-06-29" },
+                                      { "response_due" => "2021-06-30" }
+                                    ]
+                                  }
+                                })).to eq({ "response_due" => "2021-06-30" })
     end
 
     it "finds the latest date if it is in additional_document_validation_requests" do
       expect(latest_request_due({
-        "data" => {
-          "additional_document_validation_requests" => [
-            { "response_due" => "2021-07-01" },
-            { "response_due" => "2021-07-02" },
-          ],
-          "description_change_validation_requests" => [
-            { "response_due" => "2021-06-10" },
-            { "response_due" => "2021-06-04" },
-          ],
-          "replacement_document_validation_requests" => [
-            { "response_due" => "2021-06-11" },
-            { "response_due" => "2021-06-03" },
-          ],
-          "red_line_boundary_change_validation_requests" => [
-            { "response_due" => "2021-04-12" },
-            { "response_due" => "2021-06-02" },
-          ],
-          "other_change_validation_requests" => [
-            { "response_due" => "2021-06-29" },
-            { "response_due" => "2021-06-30" },
-          ],
-        },
-      })).to eq({ "response_due" => "2021-07-02" })
+                                  "data" => {
+                                    "additional_document_validation_requests" => [
+                                      { "response_due" => "2021-07-01" },
+                                      { "response_due" => "2021-07-02" }
+                                    ],
+                                    "description_change_validation_requests" => [
+                                      { "response_due" => "2021-06-10" },
+                                      { "response_due" => "2021-06-04" }
+                                    ],
+                                    "replacement_document_validation_requests" => [
+                                      { "response_due" => "2021-06-11" },
+                                      { "response_due" => "2021-06-03" }
+                                    ],
+                                    "red_line_boundary_change_validation_requests" => [
+                                      { "response_due" => "2021-04-12" },
+                                      { "response_due" => "2021-06-02" }
+                                    ],
+                                    "other_change_validation_requests" => [
+                                      { "response_due" => "2021-06-29" },
+                                      { "response_due" => "2021-06-30" }
+                                    ]
+                                  }
+                                })).to eq({ "response_due" => "2021-07-02" })
     end
   end
 end

--- a/spec/models/bops/additional_document_validation_request_spec.rb
+++ b/spec/models/bops/additional_document_validation_request_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Bops::AdditionalDocumentValidationRequest, type: :model do
 
     describe "#file" do
       it "validates presence" do
-        expect {
+        expect do
           additional_document_validation_request.valid?
-        }.to change {
+        end.to change {
           additional_document_validation_request.errors[:files]
         }.to ["Please choose at least one file to upload"]
       end

--- a/spec/models/bops/description_change_validation_request_spec.rb
+++ b/spec/models/bops/description_change_validation_request_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Bops::DescriptionChangeValidationRequest, type: :model do
 
     describe "#approved" do
       it "validates presence" do
-        expect {
+        expect do
           description_change_validation_request.valid?
-        }.to change {
+        end.to change {
           description_change_validation_request.errors[:approved]
         }.to ["Please select an option"]
       end
@@ -19,9 +19,9 @@ RSpec.describe Bops::DescriptionChangeValidationRequest, type: :model do
 
     describe "#rejection_reason" do
       it "validates presence when not approved" do
-        expect {
+        expect do
           not_approved_request.valid?
-        }.to change {
+        end.to change {
           not_approved_request.errors[:rejection_reason]
         }.to ["Please fill in the reason for disagreeing with the suggested change."]
       end

--- a/spec/models/bops/other_change_validation_request_spec.rb
+++ b/spec/models/bops/other_change_validation_request_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Bops::OtherChangeValidationRequest, type: :model do
 
     describe "#response" do
       it "validates presence" do
-        expect {
+        expect do
           other_change_validation_request.valid?
-        }.to change {
+        end.to change {
           other_change_validation_request.errors[:response]
         }.to ["Please enter your response to the planning officer's question."]
       end

--- a/spec/models/bops/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/models/bops/red_line_boundary_change_validation_request_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe Bops::RedLineBoundaryChangeValidationRequest, type: :model do
 
     describe "#approved" do
       it "validates presence" do
-        expect {
+        expect do
           red_line_boundary_change_validation_request.valid?
-        }.to change {
+        end.to change {
           red_line_boundary_change_validation_request.errors[:approved]
         }.to ["Please select an option"]
       end
@@ -19,9 +19,9 @@ RSpec.describe Bops::RedLineBoundaryChangeValidationRequest, type: :model do
 
     describe "#rejection_reason" do
       it "validates presence when not approved" do
-        expect {
+        expect do
           not_approved_request.valid?
-        }.to change {
+        end.to change {
           not_approved_request.errors[:rejection_reason]
         }.to ["Please indicate why you disagree with the proposed red line boundary."]
       end

--- a/spec/models/bops/replacement_document_validation_request_spec.rb
+++ b/spec/models/bops/replacement_document_validation_request_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Bops::ReplacementDocumentValidationRequest, type: :model do
 
     describe "#file" do
       it "validates presence" do
-        expect {
+        expect do
           replacement_document_validation_request.valid?
-        }.to change {
+        end.to change {
           replacement_document_validation_request.errors[:file]
         }.to ["Please choose a file to upload"]
       end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "spec_helper"
 
 ENV["RAILS_ENV"] ||= "test"
@@ -7,7 +9,7 @@ abort("The Rails environment is running in production mode!") if Rails.env.produ
 require "rspec/rails"
 require "webmock/rspec"
 
-Dir[Rails.root.join("spec/support/**/*.rb")].sort.each { |f| require f }
+Dir[Rails.root.join("spec/support/**/*.rb")].each { |f| require f }
 
 RSpec.configure do |config|
   config.file_fixture_path = "#{::Rails.root}/spec/fixtures"

--- a/spec/services/apis/bops/client_spec.rb
+++ b/spec/services/apis/bops/client_spec.rb
@@ -37,7 +37,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/description_change_validation_requests/5?change_access_id=#{change_access_id}",
         { data: { approved: true } }.to_json,
-        false,
+        false
       ).and_call_original
 
       described_class.patch_approved_description_change(5, planning_application_id, change_access_id)
@@ -50,7 +50,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/description_change_validation_requests/5?change_access_id=#{change_access_id}",
         { data: { approved: false, rejection_reason: "Bad description" } }.to_json,
-        false,
+        false
       ).and_call_original
 
       described_class.patch_rejected_description_change(5, planning_application_id, change_access_id, "Bad description")
@@ -63,7 +63,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/other_change_validation_requests/5?change_access_id=#{change_access_id}",
         { data: { response: "Other change looks fine" } }.to_json,
-        false,
+        false
       ).and_call_original
 
       described_class.patch_response_other_change_request(5, planning_application_id, change_access_id, "Other change looks fine")
@@ -76,7 +76,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/red_line_boundary_change_validation_requests/5?change_access_id=#{change_access_id}",
         { data: { approved: true } }.to_json,
-        false,
+        false
       ).and_call_original
 
       described_class.patch_approved_red_line_boundary_change(5, planning_application_id, change_access_id)
@@ -89,7 +89,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/red_line_boundary_change_validation_requests/5?change_access_id=#{change_access_id}",
         { data: { approved: false, rejection_reason: "Boundary looks wrong" } }.to_json,
-        false,
+        false
       ).and_call_original
 
       described_class.patch_rejected_red_line_boundary_change(5, planning_application_id, change_access_id, "Boundary looks wrong")
@@ -102,7 +102,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/additional_document_validation_requests/5?change_access_id=#{change_access_id}",
         { files: "files" },
-        true,
+        true
       ).and_call_original
 
       described_class.patch_additional_documents(5, planning_application_id, change_access_id, "files")
@@ -115,7 +115,7 @@ RSpec.describe Apis::Bops::Client do
         :patch,
         "#{planning_application_id}/replacement_document_validation_requests/5?change_access_id=#{change_access_id}",
         { file: "file" },
-        true,
+        true
       ).and_call_original
 
       described_class.patch_replacement_document(5, planning_application_id, change_access_id, "file")

--- a/spec/services/http_client_spec.rb
+++ b/spec/services/http_client_spec.rb
@@ -4,7 +4,7 @@ require "rails_helper"
 
 RSpec.describe HttpClient do
   let(:url) { "https://local-authority.bops-care.link/api/v1/planning_applications/" }
-  let(:token) { "Bearer #{ENV['API_BEARER']}" }
+  let(:token) { "Bearer #{ENV.fetch('API_BEARER', nil)}" }
   let(:headers) { spy }
 
   before do
@@ -33,7 +33,7 @@ RSpec.describe HttpClient do
         "#{url}28", { body: { new_file: "file" }, headers: { Authorization: token } }
       )
 
-      described_class.new.http_party("28", { "file": "file" })
+      described_class.new.http_party("28", { file: "file" })
     end
 
     it "when params is for more than one file makes an HTTP party connection" do
@@ -41,7 +41,7 @@ RSpec.describe HttpClient do
         "#{url}28", { body: { files: "files" }, headers: { Authorization: token } }
       )
 
-      described_class.new.http_party("28", { "files": "files" })
+      described_class.new.http_party("28", { files: "files" })
     end
   end
 end

--- a/spec/services/request_spec.rb
+++ b/spec/services/request_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 200,
-          body: "[]",
+          body: "[]"
         )
       end
 
@@ -33,15 +33,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 400,
-          body: "\"Bad request\"",
+          body: "\"Bad request\""
         )
       end
 
       it "returns a parsed JSON response body message" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::BadRequestError)
-         .with_message("{:response=>\"Bad request\", :status=>400, :http_method=>:get}")
+        end.to raise_error(described_class::BadRequestError)
+          .with_message("{:response=>\"Bad request\", :status=>400, :http_method=>:get}")
       end
     end
 
@@ -49,15 +49,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 401,
-          body: "\"Unauthorized\"",
+          body: "\"Unauthorized\""
         )
       end
 
       it "returns a parsed JSON response body message" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::UnauthorizedError)
-         .with_message("{:response=>\"Unauthorized\", :status=>401, :http_method=>:get}")
+        end.to raise_error(described_class::UnauthorizedError)
+          .with_message("{:response=>\"Unauthorized\", :status=>401, :http_method=>:get}")
       end
     end
 
@@ -65,15 +65,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 403,
-          body: "\"Forbidden\"",
+          body: "\"Forbidden\""
         )
       end
 
       it "returns a parsed JSON response body error message with status" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::ForbiddenError)
-         .with_message("{:response=>\"Forbidden\", :status=>403, :http_method=>:get}")
+        end.to raise_error(described_class::ForbiddenError)
+          .with_message("{:response=>\"Forbidden\", :status=>403, :http_method=>:get}")
       end
     end
 
@@ -81,15 +81,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 404,
-          body: "\"Record not found\"",
+          body: "\"Record not found\""
         )
       end
 
       it "returns a parsed JSON response body error message with status" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::RecordNotFoundError)
-         .with_message("{:response=>\"Record not found\", :status=>404, :http_method=>:get}")
+        end.to raise_error(described_class::RecordNotFoundError)
+          .with_message("{:response=>\"Record not found\", :status=>404, :http_method=>:get}")
       end
     end
 
@@ -97,15 +97,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 500,
-          body: "\"API error\"",
+          body: "\"API error\""
         )
       end
 
       it "returns a parsed JSON response body error message with status" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::ApiError)
-         .with_message("{:response=>\"API error\", :status=>500, :http_method=>:get}")
+        end.to raise_error(described_class::ApiError)
+          .with_message("{:response=>\"API error\", :status=>500, :http_method=>:get}")
       end
     end
 
@@ -113,15 +113,15 @@ RSpec.describe Request do
       let(:response) do
         double(
           status: 504,
-          body: "\"Timeout Error\"",
+          body: "\"Timeout Error\""
         )
       end
 
       it "returns a parsed JSON response body error message with status" do
-        expect {
+        expect do
           request.call
-        }.to raise_error(described_class::TimeoutError)
-         .with_message("{:response=>\"Timeout Error\", :status=>504, :http_method=>:get}")
+        end.to raise_error(described_class::TimeoutError)
+          .with_message("{:response=>\"Timeout Error\", :status=>504, :http_method=>:get}")
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,8 +1,10 @@
+# frozen_string_literal: true
+
 require "webmock/rspec"
 
 WebMock.disable_net_connect!(
   allow_localhost: true,
-  allow: "chromedriver.storage.googleapis.com",
+  allow: "chromedriver.storage.googleapis.com"
 )
 
 RSpec.configure do |config|
@@ -20,9 +22,7 @@ RSpec.configure do |config|
 
   config.disable_monkey_patching!
 
-  if config.files_to_run.one?
-    config.default_formatter = "doc"
-  end
+  config.default_formatter = "doc" if config.files_to_run.one?
 
   config.profile_examples = 10
   config.order = :random

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -1,5 +1,7 @@
+# frozen_string_literal: true
+
 module ApiSpecHelper
-  API_BASE_URL = "https://default.bops-care.link/api/v1/planning_applications".freeze
+  API_BASE_URL = "https://default.bops-care.link/api/v1/planning_applications"
 
   def headers
     {
@@ -7,31 +9,31 @@ module ApiSpecHelper
       "Accept-Encoding" => "gzip;q=1.0,deflate;q=0.6,identity;q=0.3",
       "Authorization" => "Bearer 123",
       "Content-Type" => "application/json",
-      "User-Agent" => "Faraday v2.3.0",
+      "User-Agent" => "Faraday v2.3.0"
     }
   end
 
   def stub_successful_get_planning_application
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28")
-    .with(headers:)
-    .to_return(status: 200, body: file_fixture("test_planning_application.json").read, headers: {})
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("test_planning_application.json").read, headers: {})
   end
 
   def stub_successful_get_change_requests
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-    .with(headers:)
-    .to_return(status: 200, body: file_fixture("test_change_request_index.json").read, headers: {})
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("test_change_request_index.json").read, headers: {})
   end
 
   def stub_rejected_patch_with_reason
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-    .with(headers:)
-    .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
   end
 
   def stub_cancelled_change_requests
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-    .with(headers:)
-    .to_return(status: 200, body: file_fixture("cancelled_validation_requests.json").read, headers: {})
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("cancelled_validation_requests.json").read, headers: {})
   end
 end

--- a/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/additional_document_validation_request.rb
@@ -5,26 +5,26 @@ RSpec.configure do |config|
     def stub_get_additional_document_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
       stub_request(
         :get,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-      )
-      .to_return(
-        body: JSON.generate(response_body),
-        status:,
-      )
+        .with(
+          headers:
+        )
+        .to_return(
+          body: JSON.generate(response_body),
+          status:
+        )
     end
 
     def stub_patch_additional_documents_validation_request(id:, planning_id:, change_access_id:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/additional_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .to_return(
-        body: "",
-        status:,
-      )
+        .to_return(
+          body: "",
+          status:
+        )
     end
   end
 

--- a/spec/support/bops_api_request_stubs/description_change_validation_requests.rb
+++ b/spec/support/bops_api_request_stubs/description_change_validation_requests.rb
@@ -5,45 +5,45 @@ RSpec.configure do |config|
     def stub_get_description_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
       stub_request(
         :get,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-      )
-      .to_return(
-        body: JSON.generate(response_body),
-        status:,
-      )
+        .with(
+          headers:
+        )
+        .to_return(
+          body: JSON.generate(response_body),
+          status:
+        )
     end
 
     def stub_patch_approved_description_change_validation_request(id:, planning_id:, change_access_id:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-        body: { data: { approved: true } }.to_json,
-      )
-      .to_return(
-        body: "{}",
-        status:,
-      )
+        .with(
+          headers:,
+          body: { data: { approved: true } }.to_json
+        )
+        .to_return(
+          body: "{}",
+          status:
+        )
     end
 
     def stub_patch_rejected_description_change_validation_request(id:, planning_id:, change_access_id:, rejection_reason:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/description_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-        body: { data: { approved: false, rejection_reason: } }.to_json,
-      )
-      .to_return(
-        body: "{}",
-        status:,
-      )
+        .with(
+          headers:,
+          body: { data: { approved: false, rejection_reason: } }.to_json
+        )
+        .to_return(
+          body: "{}",
+          status:
+        )
     end
   end
 

--- a/spec/support/bops_api_request_stubs/other_change_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/other_change_validation_request.rb
@@ -5,30 +5,30 @@ RSpec.configure do |config|
     def stub_get_other_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
       stub_request(
         :get,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-      )
-      .to_return(
-        body: JSON.generate(response_body),
-        status:,
-      )
+        .with(
+          headers:
+        )
+        .to_return(
+          body: JSON.generate(response_body),
+          status:
+        )
     end
 
     def stub_patch_other_change_validation_request(id:, planning_id:, change_access_id:, response:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/other_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-        body: { data: { response: } }.to_json,
-      )
-      .to_return(
-        body: "{}",
-        status:,
-      )
+        .with(
+          headers:,
+          body: { data: { response: } }.to_json
+        )
+        .to_return(
+          body: "{}",
+          status:
+        )
     end
   end
 

--- a/spec/support/bops_api_request_stubs/red_line_boundary_change_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/red_line_boundary_change_validation_request.rb
@@ -5,45 +5,45 @@ RSpec.configure do |config|
     def stub_get_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
       stub_request(
         :get,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-      )
-      .to_return(
-        body: JSON.generate(response_body),
-        status:,
-      )
+        .with(
+          headers:
+        )
+        .to_return(
+          body: JSON.generate(response_body),
+          status:
+        )
     end
 
     def stub_patch_approved_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-        body: { data: { approved: true } }.to_json,
-      )
-      .to_return(
-        body: "{}",
-        status:,
-      )
+        .with(
+          headers:,
+          body: { data: { approved: true } }.to_json
+        )
+        .to_return(
+          body: "{}",
+          status:
+        )
     end
 
     def stub_patch_rejected_red_line_boundary_change_validation_request(id:, planning_id:, change_access_id:, rejection_reason:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/red_line_boundary_change_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-        body: { data: { approved: false, rejection_reason: } }.to_json,
-      )
-      .to_return(
-        body: "{}",
-        status:,
-      )
+        .with(
+          headers:,
+          body: { data: { approved: false, rejection_reason: } }.to_json
+        )
+        .to_return(
+          body: "{}",
+          status:
+        )
     end
   end
 

--- a/spec/support/bops_api_request_stubs/replacement_document_validation_request.rb
+++ b/spec/support/bops_api_request_stubs/replacement_document_validation_request.rb
@@ -5,26 +5,26 @@ RSpec.configure do |config|
     def stub_get_replacement_document_validation_request(id:, planning_id:, change_access_id:, response_body:, status:)
       stub_request(
         :get,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .with(
-        headers:,
-      )
-      .to_return(
-        body: JSON.generate(response_body),
-        status:,
-      )
+        .with(
+          headers:
+        )
+        .to_return(
+          body: JSON.generate(response_body),
+          status:
+        )
     end
 
     def stub_patch_replacement_document_validation_request(id:, planning_id:, change_access_id:, status:)
       stub_request(
         :patch,
-        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}",
+        "#{ApiSpecHelper::API_BASE_URL}/#{planning_id}/replacement_document_validation_requests/#{id}?change_access_id=#{change_access_id}"
       )
-      .to_return(
-        body: "",
-        status:,
-      )
+        .to_return(
+          body: "",
+          status:
+        )
     end
   end
 

--- a/spec/support/local_authority_contact_details_spec_helper.rb
+++ b/spec/support/local_authority_contact_details_spec_helper.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.shared_context "local_authority_contact_details" do
@@ -8,8 +10,8 @@ RSpec.shared_context "local_authority_contact_details" do
         feedback_email: "planning@default.gov.uk",
         phone_number: "01234123123",
         postal_address: "Planning, 123 High Street, Big City, AB3 4EF",
-        privacy_policy: "https://www.default.gov.uk/privacy-policy",
-      },
+        privacy_policy: "https://www.default.gov.uk/privacy-policy"
+      }
     }.deep_stringify_keys
   end
 

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Document create requests", type: :system do
@@ -11,7 +13,7 @@ RSpec.describe "Document create requests", type: :system do
       document_request_type: "Roman theatre plan",
       document_request_reason: "I do not see a vomitorium in this.",
       response_due: "2022-7-1",
-      post_validation: false,
+      post_validation: false
     }.stringify_keys
   end
 
@@ -25,7 +27,7 @@ RSpec.describe "Document create requests", type: :system do
       planning_id: 28,
       change_access_id: 345_443_543,
       response_body:,
-      status: 200,
+      status: 200
     )
   end
 
@@ -34,7 +36,7 @@ RSpec.describe "Document create requests", type: :system do
       visit "/additional_document_validation_requests/3/edit?change_access_id=345443543&planning_application_id=28"
 
       expect(page).to have_content(
-        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded."
       )
 
       expect(page).to have_content("Document requested:")
@@ -44,7 +46,7 @@ RSpec.describe "Document create requests", type: :system do
 
       expect(page).to have_link(
         "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
-        href: "#{ENV['PROTOCOL']}://default.#{ENV['API_HOST']}/planning_guides/index",
+        href: "#{ENV.fetch('PROTOCOL', nil)}://default.#{ENV.fetch('API_HOST', nil)}/planning_guides/index"
       )
     end
 
@@ -56,7 +58,7 @@ RSpec.describe "Document create requests", type: :system do
           document_request_type: "Roman theatre plan",
           document_request_reason: "No room for the lions",
           response_due: "2022-7-1",
-          post_validation: true,
+          post_validation: true
         }.stringify_keys
       end
 
@@ -64,11 +66,11 @@ RSpec.describe "Document create requests", type: :system do
         visit edit_additional_document_validation_request_path(
           3,
           planning_application_id: 28,
-          change_access_id: "345443543",
+          change_access_id: "345443543"
         )
 
         expect(page).not_to have_content(
-          "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+          "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded."
         )
       end
     end
@@ -91,7 +93,7 @@ RSpec.describe "Document create requests", type: :system do
         id: 3,
         planning_id: 28,
         change_access_id: 345_443_543,
-        status: 200,
+        status: 200
       )
     end
 
@@ -112,22 +114,22 @@ RSpec.describe "Document create requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 3,
-            "state": "closed",
-            "document_request_type": "Floor plan",
-            "document_request_reason": "No floor plan.",
-            "documents": [
+            id: 3,
+            state: "closed",
+            document_request_type: "Floor plan",
+            document_request_reason: "No floor plan.",
+            documents: [
               {
-                "name": "proposed-floorplan.jpg",
-                "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan.png",
+                name: "proposed-floorplan.jpg",
+                url: "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan.png"
               },
               {
-                "name": "proposed-floorplan-2.jpg",
-                "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan-2.png",
-              },
-            ],
+                name: "proposed-floorplan-2.jpg",
+                url: "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBkdz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--c9f482b79792231cade4fd9fe59c1b622dab5713/proposed-floorplan-2.png"
+              }
+            ]
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -156,12 +158,12 @@ RSpec.describe "Document create requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 3,
-            "state": "cancelled",
-            "cancel_reason": "My mistake",
-            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+            id: 3,
+            state: "cancelled",
+            cancel_reason: "My mistake",
+            cancelled_at: "2021-10-20T11:42:50.951+01:00"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -185,7 +187,7 @@ RSpec.describe "Document create requests", type: :system do
         document_request_type: "Link to https://www.bops.co.uk/type",
         document_request_reason: "View reason <a href='https://www.bops.co.uk/reason'>Request reason</a>",
         response_due: "2022-7-1",
-        post_validation: false,
+        post_validation: false
       }.stringify_keys
     end
 
@@ -194,12 +196,12 @@ RSpec.describe "Document create requests", type: :system do
 
       expect(page).to have_link(
         "https://www.bops.co.uk/type",
-        href: "https://www.bops.co.uk/type",
+        href: "https://www.bops.co.uk/type"
       )
 
       expect(page).to have_link(
         "Request reason",
-        href: "https://www.bops.co.uk/reason",
+        href: "https://www.bops.co.uk/reason"
       )
     end
   end

--- a/spec/system/description_change_request_spec.rb
+++ b/spec/system/description_change_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Description change requests", type: :system do
@@ -14,11 +16,11 @@ RSpec.describe "Description change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 22,
-          "state": "open",
-          "response_due": "2022-7-1",
+          id: 22,
+          state: "open",
+          response_due: "2022-7-1"
         },
-      status: 200,
+      status: 200
     )
   end
 
@@ -29,7 +31,7 @@ RSpec.describe "Description change requests", type: :system do
           id: 22,
           planning_id: 28,
           change_access_id: 345_443_543,
-          status: 200,
+          status: 200
         )
       end
 
@@ -37,7 +39,7 @@ RSpec.describe "Description change requests", type: :system do
         visit "/description_change_validation_requests/22/edit?change_access_id=345443543&planning_application_id=28"
 
         expect(page).to have_content(
-          "If your response is not received by 1 July 2022 the proposed description will be automatically accepted for use with your application.",
+          "If your response is not received by 1 July 2022 the proposed description will be automatically accepted for use with your application."
         )
 
         choose "Yes, I agree with the changes made"
@@ -62,7 +64,7 @@ RSpec.describe "Description change requests", type: :system do
           planning_id: 28,
           change_access_id: 345_443_543,
           rejection_reason: "I wish to build a roman theatre",
-          status: 200,
+          status: 200
         )
       end
 
@@ -110,12 +112,12 @@ RSpec.describe "Description change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 22,
-          "state": "closed",
-          "approved": true,
+          id: 22,
+          state: "closed",
+          approved: true
 
         },
-      status: 200,
+      status: 200
     )
 
     visit "/description_change_validation_requests/22?change_access_id=345443543&planning_application_id=28"
@@ -130,12 +132,12 @@ RSpec.describe "Description change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 22,
-            "state": "closed",
-            "proposed_description": "I wish to build a roman theatre.",
-            "approved": false,
+            id: 22,
+            state: "closed",
+            proposed_description: "I wish to build a roman theatre.",
+            approved: false
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -161,12 +163,12 @@ RSpec.describe "Description change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 22,
-            "state": "cancelled",
-            "cancel_reason": "My mistake",
-            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+            id: 22,
+            state: "cancelled",
+            cancel_reason: "My mistake",
+            cancelled_at: "2021-10-20T11:42:50.951+01:00"
           },
-        status: 200,
+        status: 200
       )
     end
 

--- a/spec/system/healthcheck_spec.rb
+++ b/spec/system/healthcheck_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "healthcheck", type: :system do

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "landing page", type: :system do
@@ -12,8 +14,8 @@ RSpec.describe "landing page", type: :system do
     visit(
       validation_requests_path(
         planning_application_id: 28,
-        change_access_id: 345_443_543,
-      ),
+        change_access_id: 345_443_543
+      )
     )
   end
 
@@ -32,7 +34,7 @@ RSpec.describe "landing page", type: :system do
       within("footer") { click_link("Accessibility statement") }
 
       expect(page).to have_content(
-        "Accessibility statement for Default Council Back-office Planning System",
+        "Accessibility statement for Default Council Back-office Planning System"
       )
 
       expect(page).to have_content("Email planning@default.gov.uk")

--- a/spec/system/other_change_validation_request_spec.rb
+++ b/spec/system/other_change_validation_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Other change requests", type: :system do
@@ -14,13 +16,13 @@ RSpec.describe "Other change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 19,
-          "state": "open",
-          "summary": "You applied for the wrong sort of certificate",
-          "suggestion": "Please confirm you want a Lawful Development certificate",
-          "response_due": "2022-7-1",
+          id: 19,
+          state: "open",
+          summary: "You applied for the wrong sort of certificate",
+          suggestion: "Please confirm you want a Lawful Development certificate",
+          response_due: "2022-7-1"
         },
-      status: 200,
+      status: 200
     )
   end
 
@@ -31,7 +33,7 @@ RSpec.describe "Other change requests", type: :system do
         planning_id: 28,
         change_access_id: 345_443_543,
         response: "Agreed",
-        status: 200,
+        status: 200
       )
     end
 
@@ -39,7 +41,7 @@ RSpec.describe "Other change requests", type: :system do
       visit "/other_change_validation_requests/19/edit?change_access_id=345443543&planning_application_id=28"
 
       expect(page).to have_content(
-        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded."
       )
 
       expect(page).to have_content("You applied for the wrong sort of certificate")
@@ -82,11 +84,11 @@ RSpec.describe "Other change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 19,
-            "state": "closed",
-            "response": "I accept the change",
+            id: 19,
+            state: "closed",
+            response: "I accept the change"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -110,12 +112,12 @@ RSpec.describe "Other change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 19,
-            "state": "cancelled",
-            "cancel_reason": "My mistake",
-            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+            id: 19,
+            state: "cancelled",
+            cancel_reason: "My mistake",
+            cancelled_at: "2021-10-20T11:42:50.951+01:00"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -139,13 +141,13 @@ RSpec.describe "Other change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 19,
-            "state": "open",
-            "summary": "Details are on https://www.bops.co.uk/info",
-            "suggestion": "View to see <a href='https://www.bops.co.uk/payment'>Payment info</a>",
-            "response_due": "2022-7-1",
+            id: 19,
+            state: "open",
+            summary: "Details are on https://www.bops.co.uk/info",
+            suggestion: "View to see <a href='https://www.bops.co.uk/payment'>Payment info</a>",
+            response_due: "2022-7-1"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -154,12 +156,12 @@ RSpec.describe "Other change requests", type: :system do
 
       expect(page).to have_link(
         "https://www.bops.co.uk/info",
-        href: "https://www.bops.co.uk/info",
+        href: "https://www.bops.co.uk/info"
       )
 
       expect(page).to have_link(
         "Payment info",
-        href: "https://www.bops.co.uk/payment",
+        href: "https://www.bops.co.uk/payment"
       )
     end
   end

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Red line boundary change requests", type: :system do
@@ -14,14 +16,14 @@ RSpec.describe "Red line boundary change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 10,
-          "state": "open",
-          "new_geojson": "",
-          "reason": nil,
-          "approved": nil,
-          "response_due": "2022-7-1",
+          id: 10,
+          state: "open",
+          new_geojson: "",
+          reason: nil,
+          approved: nil,
+          response_due: "2022-7-1"
         },
-      status: 200,
+      status: 200
     )
   end
 
@@ -32,7 +34,7 @@ RSpec.describe "Red line boundary change requests", type: :system do
           id: 10,
           planning_id: 28,
           change_access_id: 345_443_543,
-          status: 200,
+          status: 200
         )
       end
 
@@ -40,7 +42,7 @@ RSpec.describe "Red line boundary change requests", type: :system do
         visit "/red_line_boundary_change_validation_requests/10/edit?change_access_id=345443543&planning_application_id=28"
 
         expect(page).to have_content(
-          "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+          "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded."
         )
 
         choose "Yes, I agree with the proposed red line boundary"
@@ -65,7 +67,7 @@ RSpec.describe "Red line boundary change requests", type: :system do
           planning_id: 28,
           change_access_id: 345_443_543,
           rejection_reason: "I think the boundary is wrong",
-          status: 200,
+          status: 200
         )
       end
 
@@ -118,11 +120,11 @@ RSpec.describe "Red line boundary change requests", type: :system do
           change_access_id: 345_443_543,
           response_body:
             {
-              "id": 10,
-              "state": "closed",
-              "approved": true,
+              id: 10,
+              state: "closed",
+              approved: true
             },
-          status: 200,
+          status: 200
         )
       end
 
@@ -146,12 +148,12 @@ RSpec.describe "Red line boundary change requests", type: :system do
           change_access_id: 345_443_543,
           response_body:
             {
-              "id": 10,
-              "state": "closed",
-              "rejection_reason": "I do not agree with this boundary",
-              "approved": false,
+              id: 10,
+              state: "closed",
+              rejection_reason: "I do not agree with this boundary",
+              approved: false
             },
-          status: 200,
+          status: 200
         )
       end
 
@@ -173,12 +175,12 @@ RSpec.describe "Red line boundary change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 10,
-            "state": "cancelled",
-            "cancel_reason": "My mistake",
-            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+            id: 10,
+            state: "cancelled",
+            cancel_reason: "My mistake",
+            cancelled_at: "2021-10-20T11:42:50.951+01:00"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -202,14 +204,14 @@ RSpec.describe "Red line boundary change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 10,
-            "state": "open",
-            "new_geojson": "",
-            "reason": "Reason on https://www.bops.co.uk/reason",
-            "approved": nil,
-            "response_due": "2022-7-1",
+            id: 10,
+            state: "open",
+            new_geojson: "",
+            reason: "Reason on https://www.bops.co.uk/reason",
+            approved: nil,
+            response_due: "2022-7-1"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -218,7 +220,7 @@ RSpec.describe "Red line boundary change requests", type: :system do
 
       expect(page).to have_link(
         "https://www.bops.co.uk/reason",
-        href: "https://www.bops.co.uk/reason",
+        href: "https://www.bops.co.uk/reason"
       )
     end
   end

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Document change requests", type: :system do
@@ -15,15 +17,15 @@ RSpec.describe "Document change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 8,
-          "state": "open",
-          "old_document": {
-            "name": "20210512_162911.jpg",
-            "invalid_document_reason": "Its a chicken coop not a floor plan.",
+          id: 8,
+          state: "open",
+          old_document: {
+            name: "20210512_162911.jpg",
+            invalid_document_reason: "Its a chicken coop not a floor plan."
           },
-          "response_due": "2022-7-1",
+          response_due: "2022-7-1"
         },
-      status: 200,
+      status: 200
     )
   end
 
@@ -33,7 +35,7 @@ RSpec.describe "Document change requests", type: :system do
         id: 8,
         planning_id: 28,
         change_access_id: 345_443_543,
-        status: 200,
+        status: 200
       )
     end
 
@@ -41,7 +43,7 @@ RSpec.describe "Document change requests", type: :system do
       visit "/replacement_document_validation_requests/8/edit?change_access_id=345443543&planning_application_id=28"
 
       expect(page).to have_content(
-        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded.",
+        "If your response is not received by 1 July 2022 your application will be returned to you and your payment refunded."
       )
 
       expect(page).to have_content("Name of file on submission:")
@@ -51,7 +53,7 @@ RSpec.describe "Document change requests", type: :system do
 
       expect(page).to have_link(
         "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
-        href: "#{ENV['PROTOCOL']}://default.#{ENV['API_HOST']}/planning_guides/index",
+        href: "#{ENV.fetch('PROTOCOL', nil)}://default.#{ENV.fetch('API_HOST', nil)}/planning_guides/index"
       )
     end
 
@@ -83,18 +85,18 @@ RSpec.describe "Document change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 8,
-            "state": "closed",
-            "old_document": {
-              "name": "paul-volkmer.jpg",
-              "invalid_document_reason": "Its a galaxy.",
+            id: 8,
+            state: "closed",
+            old_document: {
+              name: "paul-volkmer.jpg",
+              invalid_document_reason: "Its a galaxy."
             },
-            "new_document": {
-              "name": "max-baskakov-catunsplash.jpg",
-              "url": "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBRZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--772d855213ddd9220ca829cec75caaafe68a3fc8/max-baskakov-catunsplash.jpg",
-            },
+            new_document: {
+              name: "max-baskakov-catunsplash.jpg",
+              url: "http://southwark.bops-care.link:3000/rails/active_storage/blobs/redirect/eyJfcmFpbHMiOnsibWVzc2FnZSI6IkJBaHBRZz09IiwiZXhwIjpudWxsLCJwdXIiOiJibG9iX2lkIn19--772d855213ddd9220ca829cec75caaafe68a3fc8/max-baskakov-catunsplash.jpg"
+            }
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -123,12 +125,12 @@ RSpec.describe "Document change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 8,
-            "state": "cancelled",
-            "cancel_reason": "My mistake",
-            "cancelled_at": "2021-10-20T11:42:50.951+01:00",
+            id: 8,
+            state: "cancelled",
+            cancel_reason: "My mistake",
+            cancelled_at: "2021-10-20T11:42:50.951+01:00"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -155,15 +157,15 @@ RSpec.describe "Document change requests", type: :system do
         change_access_id: 345_443_543,
         response_body:
           {
-            "id": 8,
-            "state": "open",
-            "old_document": {
-              "name": "20210512_162911.jpg",
-              "invalid_document_reason": "Invalid reason can be found on https://www.bops.co.uk/invalid_document_reason",
+            id: 8,
+            state: "open",
+            old_document: {
+              name: "20210512_162911.jpg",
+              invalid_document_reason: "Invalid reason can be found on https://www.bops.co.uk/invalid_document_reason"
             },
-            "response_due": "2022-7-1",
+            response_due: "2022-7-1"
           },
-        status: 200,
+        status: 200
       )
     end
 
@@ -172,7 +174,7 @@ RSpec.describe "Document change requests", type: :system do
 
       expect(page).to have_link(
         "https://www.bops.co.uk/invalid_document_reason",
-        href: "https://www.bops.co.uk/invalid_document_reason",
+        href: "https://www.bops.co.uk/invalid_document_reason"
       )
     end
   end

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require "rails_helper"
 
 RSpec.describe "Change requests", type: :system do
@@ -21,7 +23,7 @@ RSpec.describe "Change requests", type: :system do
 
   it "forbids the user from accessing change requests for a different application" do
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
-    .to_return(status: 401, body: "{}")
+      .to_return(status: 401, body: "{}")
     stub_successful_get_planning_application
 
     visit "/validation_requests?planning_application_id=28&change_access_id=345443543"
@@ -52,12 +54,12 @@ RSpec.describe "Change requests", type: :system do
       change_access_id: 345_443_543,
       response_body:
         {
-          "id": 18,
-          "state": "open",
-          "proposed_description": "This is a better description",
-          "response_due": "2022-7-1",
+          id: 18,
+          state: "open",
+          proposed_description: "This is a better description",
+          response_due: "2022-7-1"
         },
-      status: 200,
+      status: 200
     )
 
     click_link("Description", match: :first)


### PR DESCRIPTION
BOPS has a different configuration for Rubocop. In practice that isn't a big deal but it did mean that newly-introduced Rubocop rules weren't being applied. It seemed to make sense to both enable new rules and apply the other rules from BOPS at the same time.