### PR TITLE
Update invalid webpack configuration object

### DIFF
--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -10,7 +10,7 @@ module.exports = {
     govuk: "./app/javascript/govuk.js",
   },
   optimization: {
-    moduleIds: "deterministic",
+    moduleIds: "natural",
   },
   output: {
     filename: "[name].js",


### PR DESCRIPTION
Error: Webpack has been initialised using a configuration object that does not match the API schema.

- configuration.optimization.moduleIds should be one of these: "natural" | "named" | "hashed" | "size" | "total-size" | false
-> Define the algorithm to choose module ids (natural: numeric ids in order of usage, named: readable ids for better debugging, hashed: short hashes as ids for better long term caching, size: numeric ids focused on minimal initial download size, total-size: numeric ids focused on minimal total download size, false: no algorithm used, as custom one can be provided via plugin)