### PR TITLE
Include subdomain in doc links

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -38,6 +38,6 @@ class PlanningApplicationsController < ApplicationController
   end
 
   def set_base_url
-    @base_url = "#{ENV.fetch('PROTOCOL', nil)}://#{ENV.fetch('API_HOST', 'bops-care.link')}"
+    @base_url = "#{ENV.fetch('PROTOCOL', nil)}://#{Current.local_authority}.#{ENV.fetch('API_HOST', 'bops-care.link')}"
   end
 end


### PR DESCRIPTION
Wasn't including the subdomain in the documents link which was somehow working locally but not on staging