### PR TITLE
Remove 'please' from commenting instructions

### DIFF
--- a/app/views/planning_applications/show.html.erb
+++ b/app/views/planning_applications/show.html.erb
@@ -20,9 +20,9 @@
 
 <div class="contact-box">
   <p class="govuk-body">
-    To comment on this application, please send an email to 
-    <%= mail_to @local_authority["email_address"], subject: @planning_application["reference"] %>
-    and use the application reference number above as the email subject. 
+    To comment on this application, send an email to 
+    <%= mail_to @local_authority["email_address"], subject: @planning_application["reference"] %>. 
+    Use the application reference number above as the email subject. 
   </p>
   <p class="govuk-body govuk-!-margin-bottom-0">
     <a href="#application-comments-instructions">Click here for guidance on making a comment</a>.

--- a/spec/system/planning_applications_spec.rb
+++ b/spec/system/planning_applications_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Planning applications", type: :system do
     expect(map_selector["latitude"]).to eq("123")
     expect(map_selector["longitude"]).to eq("-123")
 
-    expect(page).to have_content("To comment on this application, please send an email to planning@southwark.com and use the application reference number above as the email subject")
+    expect(page).to have_content("To comment on this application, send an email to planning@southwark.com. Use the application reference number above as the email subject")
     expect(page).to have_content("This is the site plan")
     expect(page).to have_content("PLAN02")
     expect(page).to have_css("img[src*='http://example.com/document_path2.pdf']")


### PR DESCRIPTION
We shouldn't use the word please in our content