### PR TITLE
Only show applications officers have made public

### DIFF
--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -9,8 +9,12 @@ class PlanningApplicationsController < ApplicationController
   before_action :set_base_url
 
   def show
-    respond_to do |format|
-      format.html
+    if @planning_application["make_public"]
+      respond_to do |format|
+        format.html
+      end
+    else
+      render_not_found
     end
   end
 

--- a/spec/fixtures/test_private_planning_application.json
+++ b/spec/fixtures/test_private_planning_application.json
@@ -11,7 +11,7 @@
   "created_at": "2021-04-23T10:15:42.444Z",
   "description": "Add a chimney stack",
   "determined_at": null,
-  "id": 28,
+  "id": 29,
   "invalidated_at": "2021-04-23T10:15:52.855Z",
   "in_assessment_at": null,
   "payment_reference": "PAY1",
@@ -76,5 +76,5 @@
       "summary_tag": "objection"
     }
   ],
-  "make_public": true
+  "make_public": false
 }

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -19,6 +19,12 @@ module ApiSpecHelper
       .to_return(status: 200, body: file_fixture("test_planning_application.json").read, headers: {})
   end
 
+  def stub_successful_get_private_planning_application
+    stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/29")
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("test_private_planning_application.json").read, headers: {})
+  end
+
   def stub_unsuccessful_get_planning_application
     stub_request(:get, "https://default.bops-care.link/api/v1/planning_applications/100")
       .with(headers:)

--- a/spec/system/planning_applications_spec.rb
+++ b/spec/system/planning_applications_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Planning applications", type: :system do
     ENV["PROTOCOL"] = "https"
   end
 
-  it "allows the user to see a planning application" do
+  it "allows the user to see a planning application if it's public" do
     stub_successful_get_planning_application
     stub_successful_get_local_authority
 
@@ -42,6 +42,15 @@ RSpec.describe "Planning applications", type: :system do
     stub_unsuccessful_get_planning_application
 
     visit "/planning_applications/100"
+
+    expect(page).to have_content("Not Found")
+  end
+
+  it "shows 404 if officer hasn't made planning application public" do
+    stub_successful_get_private_planning_application
+    stub_successful_get_local_authority
+
+    visit "/planning_applications/29"
 
     expect(page).to have_content("Not Found")
   end


### PR DESCRIPTION
BoPS applicants half of: 
https://trello.com/c/37TImALj/1785-restrict-cases-displayed-online

Checks the API to see if officer has made application should be public, if not it renders a 404