### PR TITLE
Improve the reliability when running the app in docker

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,4 @@
 DOCKER-RUN = docker compose run --rm web
-BUNDLE-RUN = bundle exec
 
 .DEFAULT_GOAL := up
 
@@ -16,4 +15,4 @@ prompt:
 	$(DOCKER-RUN) bash
 
 lint:
-	$(DOCKER-RUN) $(BUNDLE-RUN) rubocop
+	$(DOCKER-RUN) rubocop

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
-DOCKER-RUN = docker-compose run --rm web
+DOCKER-RUN = docker compose run --rm web
 BUNDLE-RUN = bundle exec
 
 .DEFAULT_GOAL := up
 
 build:
-	docker-compose build
+	docker compose build
 
 up:
-	docker-compose up
+	docker compose up
 
 prompt:
 	$(DOCKER-RUN) bash

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,9 @@ build:
 up:
 	docker compose up
 
+down:
+	docker compose down
+
 prompt:
 	$(DOCKER-RUN) bash
 

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,7 @@ build:
 	docker compose build
 
 up:
-	docker compose up
+	docker compose up || true
 
 down:
 	docker compose down

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,10 @@ services:
       - type: volume
         source: node_modules
         target: /home/rails/bops-applicants/node_modules
-    tmpfs:
-      - /tmp/pids/
+      - type: tmpfs
+        target: /tmp/pids
+        tmpfs:
+          mode: 0777
 
 volumes:
   bundle:

--- a/docker/ruby/docker-entrypoint.sh
+++ b/docker/ruby/docker-entrypoint.sh
@@ -8,5 +8,5 @@ else
   yarn install
   bundle check || bundle install
 
-  bundle exec "$@"
+  exec bundle exec "$@"
 fi


### PR DESCRIPTION
* Fixing file permissions on `/tmp/pids` ensures that the container restarts correctly
* Using `exec bundle exec` ensures that foreman gets the interrupt signal