### PR TITLE
Do not read from ENV directly post initialization

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,11 +23,6 @@ AllCops:
     - "config/puma.rb"
     - "vendor/**/*"
 
-# TODO
-Rails/EnvironmentVariableAccess:
-  Exclude:
-    - app/**/*
-
 # past migrations are ignored; we don't expect to go back and edit them ever,
 # we'll fix them in future migrations if at all.
 Rails/BulkChangeTable:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,24 +23,6 @@ AllCops:
     - "config/puma.rb"
     - "vendor/**/*"
 
-# past migrations are ignored; we don't expect to go back and edit them ever,
-# we'll fix them in future migrations if at all.
-Rails/BulkChangeTable:
-  Exclude:
-    - db/migrate/2020*
-    - db/migrate/2021*
-    - db/migrate/2022*
-
-Rails/ReversibleMigration:
-  Exclude:
-    - db/migrate/2020*
-    - db/migrate/2021*
-    - db/migrate/2022*
-
-Rails/ThreeStateBooleanColumn:
-  Exclude:
-    - db/migrate/2020*
-    - db/migrate/2021*
-    - db/migrate/2022*
-    - db/migrate/20230*
-    - db/migrate/202310*
+Style/FrozenStringLiteralComment:
+  Enabled: true
+  EnforcedStyle: always_true

--- a/app/components/consultation_status_component.rb
+++ b/app/components/consultation_status_component.rb
@@ -67,6 +67,6 @@ class ConsultationStatusComponent < ViewComponent::Base
   end
 
   def decision_notice_link
-    "#{ENV["PROTOCOL"]}://#{Current.local_authority}.#{ENV["API_HOST"]}/public/planning_applications/#{planning_application["id"]}/decision_notice"
+    "#{Rails.configuration.api_protocol}://#{Current.local_authority}.#{Rails.configuration.api_host}/public/planning_applications/#{planning_application["id"]}/decision_notice"
   end
 end

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -37,7 +37,7 @@ class PlanningApplicationsController < ApplicationController
   end
 
   def set_base_url
-    @base_url = "#{ENV.fetch("PROTOCOL", nil)}://#{Current.local_authority}.#{ENV.fetch("API_HOST", "bops-care.link")}"
+    @base_url = "#{Rails.configuration.api_protocol}://#{Current.local_authority}.#{Rails.configuration.api_host}"
   end
 
   def set_header_link

--- a/app/services/http_client.rb
+++ b/app/services/http_client.rb
@@ -4,7 +4,7 @@ class HttpClient
   attr_reader :api_base_url
 
   def initialize
-    @api_base_url = "#{ENV.fetch("PROTOCOL", nil)}://#{api_base}/"
+    @api_base_url = "#{Rails.configuration.api_protocol}://#{api_base}/"
   end
 
   def connection
@@ -37,10 +37,10 @@ class HttpClient
   end
 
   def api_base
-    "#{Current.local_authority}.#{ENV.fetch("API_HOST", "bops-care.link")}/api/v1"
+    "#{Current.local_authority}.#{Rails.configuration.api_host}/api/v1"
   end
 
   def authorization_header
-    "Bearer #{ENV.fetch("API_BEARER", nil)}"
+    "Bearer #{Rails.configuration.api_bearer}"
   end
 end

--- a/app/views/shared/_planning_guides_link.html.erb
+++ b/app/views/shared/_planning_guides_link.html.erb
@@ -1,4 +1,4 @@
 <p class="govuk-body">
   <%= link_to "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
-    "#{ENV['PROTOCOL']}://#{Current.local_authority}.#{ENV['API_HOST']}/planning_guides/index", class: "govuk-link", target: "_blank" %>
+    "#{Rails.configuration.api_protocol}://#{Current.local_authority}.#{Rails.configuration.api_host}/planning_guides/index", class: "govuk-link", target: "_blank" %>
 </p>

--- a/config/application.rb
+++ b/config/application.rb
@@ -43,6 +43,6 @@ module BopsApplicants
     # Don't log certain requests that spam the log files
     config.middleware.insert_before Rails::Rack::Logger, QuietLogger, paths: ["/healthcheck"]
 
-    config.os_vector_tiles_api_key = ENV.fetch("OS_VECTOR_TILES_API_KEY", nil)
+    config.os_vector_tiles_api_key = ENV["OS_VECTOR_TILES_API_KEY"]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,8 @@ module BopsApplicants
     config.middleware.insert_before Rails::Rack::Logger, QuietLogger, paths: ["/healthcheck"]
 
     config.os_vector_tiles_api_key = ENV["OS_VECTOR_TILES_API_KEY"]
+    config.api_host = ENV.fetch("API_HOST", "bops-care.link")
+    config.api_protocol = ENV["PROTOCOL"]
+    config.api_bearer = ENV["API_BEARER"]
   end
 end

--- a/spec/services/http_client_spec.rb
+++ b/spec/services/http_client_spec.rb
@@ -4,12 +4,12 @@ require "rails_helper"
 
 RSpec.describe HttpClient do
   let(:url) { "https://local-authority.bops-care.link/api/v1/" }
-  let(:token) { "Bearer #{ENV.fetch("API_BEARER", nil)}" }
+  let(:token) { "Bearer #{Rails.configuration.api_bearer}" }
   let(:headers) { spy }
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
     allow(Current).to receive(:local_authority).and_return("local-authority")
   end
 

--- a/spec/system/additional_document_validation_request_spec.rb
+++ b/spec/system/additional_document_validation_request_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe "Document create requests", type: :system do
   end
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_planning_application
     stub_get_additional_document_validation_request(
@@ -51,7 +51,7 @@ RSpec.describe "Document create requests", type: :system do
 
       expect(page).to have_link(
         "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
-        href: "#{ENV.fetch("PROTOCOL", nil)}://default.#{ENV.fetch("API_HOST", nil)}/planning_guides/index"
+        href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/planning_guides/index"
       )
     end
 

--- a/spec/system/consultation_status_spec.rb
+++ b/spec/system/consultation_status_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Planning applications", type: :system do
 
   before do
     ENV["OS_VECTOR_TILES_API_KEY"] = "testtest"
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_local_authority
   end
@@ -89,7 +89,7 @@ RSpec.describe "Planning applications", type: :system do
 
           expect(page).to have_link(
             "View decision notice",
-            href: "#{ENV.fetch("PROTOCOL", nil)}://default.#{ENV.fetch("API_HOST", nil)}/public/planning_applications/28/decision_notice"
+            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/28/decision_notice"
           )
         end
       end
@@ -119,7 +119,7 @@ RSpec.describe "Planning applications", type: :system do
 
           expect(page).to have_link(
             "View decision notice",
-            href: "#{ENV.fetch("PROTOCOL", nil)}://default.#{ENV.fetch("API_HOST", nil)}/public/planning_applications/28/decision_notice"
+            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/28/decision_notice"
           )
         end
       end

--- a/spec/system/description_change_request_spec.rb
+++ b/spec/system/description_change_request_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Description change requests", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_planning_application
     stub_get_description_change_validation_request(

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "landing page", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
     stub_successful_get_change_requests
     stub_successful_get_planning_application
 

--- a/spec/system/neighbour_submits_comment_spec.rb
+++ b/spec/system/neighbour_submits_comment_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe "Planning applications", js: true, type: :system do
 
   before do
     ENV["OS_VECTOR_TILES_API_KEY"] = "testtest"
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
     stub_request(:get, "https://api.os.uk/search/places/v1/find").with(query: hash_including({}))
   end
 

--- a/spec/system/other_change_validation_request_spec.rb
+++ b/spec/system/other_change_validation_request_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Other change requests", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_planning_application
     stub_get_other_change_validation_request(

--- a/spec/system/planning_applications_spec.rb
+++ b/spec/system/planning_applications_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Planning applications", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
   end
 
   it "allows the user to see a planning application if it's public" do

--- a/spec/system/red_line_boundary_change_validation_request_spec.rb
+++ b/spec/system/red_line_boundary_change_validation_request_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Red line boundary change requests", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_planning_application
     stub_get_red_line_boundary_change_validation_request(

--- a/spec/system/replacement_document_validation_request_spec.rb
+++ b/spec/system/replacement_document_validation_request_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe "Document change requests", type: :system do
   include ActionDispatch::TestProcess::FixtureFile
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
 
     stub_successful_get_planning_application
     stub_get_replacement_document_validation_request(
@@ -58,7 +58,7 @@ RSpec.describe "Document change requests", type: :system do
 
       expect(page).to have_link(
         "Please ensure you have read how to correctly prepare plans (Opens in a new window or tab)",
-        href: "#{ENV.fetch("PROTOCOL", nil)}://default.#{ENV.fetch("API_HOST", nil)}/planning_guides/index"
+        href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/planning_guides/index"
       )
     end
 

--- a/spec/system/site_notices_spec.rb
+++ b/spec/system/site_notices_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Site notices", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
   end
 
   it "allows the user to see a planning application if it's public" do

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe "Change requests", type: :system do
   include_context "local_authority_contact_details"
 
   before do
-    ENV["API_BEARER"] = "123"
-    ENV["PROTOCOL"] = "https"
+    Rails.configuration.api_bearer = "123"
+    Rails.configuration.api_protocol = "https"
   end
 
   it "allows the user to see change requests associated with their application" do


### PR DESCRIPTION
- Don't use ENV.fetch with a default of nil
- Do not read from ENV directly post initialization
- Tidy up .rubocop.yml
