### PR TITLE
Set font correctly

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,4 +1,5 @@
 $govuk-assets-path: "govuk-frontend/dist/govuk/assets/";
+$govuk-font-family: open-sans, sans-serif;
 @import "govuk-frontend/dist/govuk/all";
 @import "accessible-autocomplete/dist/accessible-autocomplete.min";
 @import "components/buttons";
@@ -8,10 +9,6 @@ $govuk-assets-path: "govuk-frontend/dist/govuk/assets/";
 .image-border {
   width: 276px;
   border: solid 1px #eee;
-}
-
-html * {
-  font-family: open-sans, sans-serif !important;
 }
 
 .contact-box {

--- a/app/views/site_notices/download.html.erb
+++ b/app/views/site_notices/download.html.erb
@@ -11,12 +11,12 @@
 
 <div class="display-none">
   <div id="site-notice-content">
-    <div style="width: 430px;">
+    <div style="width: 430px; font-family: Arial;">
       <%= @planning_application["site_notice_content"].html_safe %>
     </div>
   </div>
 </div>
 
 <div data-controller="pdf">
-  <%= link_to "Download printable PDF", "#", "data-action": "click->pdf#handleClick" %>
+  <%= link_to "Download printable PDF", "#", "data-action": "click->pdf#handleClick", class: "govuk-link govuk-body" %>
 </div>


### PR DESCRIPTION
We shouldn't be overwriting $govuk-font-family by setting !important on font-family. This then fixes the site notice spacing too.