### PR TITLE
Add link to ownership certificates view

### DIFF
--- a/app/views/ownership_certificates/edit.html.erb
+++ b/app/views/ownership_certificates/edit.html.erb
@@ -37,7 +37,7 @@
         <%= form.govuk_radio_button :notification_of_owners, 'some', label: { text: 'Yes, some of them' } %>
         <%= form.govuk_radio_button :notification_of_owners, 'no', label: { text: 'No' } do %>
           <p class="govuk-body">
-            You must notify owners about this application. Use a notification form to send them details of the proposed work
+            You must notify owners about this application. Use a <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link" %> to send them details of the proposed work.
           </p>
         <% end %>
       <% end %>


### PR DESCRIPTION
This PR adds a link to the owner certificate form to make it easier for the applicant to see what to do.