### PR TITLE
Add ownership form link to show page

### DIFF
--- a/app/views/ownership_certificates/edit.html.erb
+++ b/app/views/ownership_certificates/edit.html.erb
@@ -37,7 +37,7 @@
         <%= form.govuk_radio_button :notification_of_owners, 'some', label: { text: 'Yes, some of them' } %>
         <%= form.govuk_radio_button :notification_of_owners, 'no', label: { text: 'No' } do %>
           <p class="govuk-body">
-            You must notify owners about this application. Use a <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link" %> to send them details of the proposed work.
+            You must notify owners about this application. Use a <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link", target: "_blank" %> to send them details of the proposed work.
           </p>
         <% end %>
       <% end %>

--- a/app/views/ownership_certificates/new.html.erb
+++ b/app/views/ownership_certificates/new.html.erb
@@ -36,7 +36,7 @@
         <%= form.govuk_radio_button :notification_of_owners, 'some', label: { text: 'Yes, some of them' } %>
         <%= form.govuk_radio_button :notification_of_owners, 'no', label: { text: 'No' } do %>
           <p class="govuk-body">
-            You must notify owners about this application. Use a notification form to send them details of the proposed work
+            You must notify owners about this application. Use a <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link", target: "_blank" %> to send them details of the proposed work
           </p>
         <% end %>
       <% end %>

--- a/app/views/ownership_certificates/show.html.erb
+++ b/app/views/ownership_certificates/show.html.erb
@@ -22,7 +22,7 @@
         </p>
         <p class="govuk-body">
           If you know the other owners' details, you must tell them about this application. You need to do this in writing
-          (by email or letter). You can use this <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link" %> to share the right information.
+          (by email or letter). You can use this <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link", target: "_blank" %> to share the right information.
         </p>
       </div>
     </div>

--- a/app/views/ownership_certificates/show.html.erb
+++ b/app/views/ownership_certificates/show.html.erb
@@ -22,7 +22,7 @@
         </p>
         <p class="govuk-body">
           If you know the other owners' details, you must tell them about this application. You need to do this in writing
-          (by email or letter). You can use this notification form to share the right information
+          (by email or letter). You can use this <%= link_to "notification form", "https://ecab.planningportal.co.uk/uploads/1app/notices/notice1.pdf", class: "govuk-link" %> to share the right information.
         </p>
       </div>
     </div>


### PR DESCRIPTION
The helpful link to the external form on the Ownership Certificate pages was previously added to the Edit view. This additionally adds it to the Show view and the New view.