### PR TITLE
Show carriage returns in pre-commencement conditions

### DIFF
--- a/app/views/pre_commencement_condition_validation_requests/edit.html.erb
+++ b/app/views/pre_commencement_condition_validation_requests/edit.html.erb
@@ -28,14 +28,10 @@
       <hr class="govuk-section-break govuk-section-break--xl govuk-section-break--visible">
 
       <h3 class="govuk-heading-s">Condition: <%= "#{@validation_request["condition"]["title"]}" %></h3>
-      <p class="govuk-body">
-        <%= @validation_request["condition"]["text"] %>
-      </p>
+      <%= render(FormattedContentComponent.new(text: @validation_request["condition"]["text"])) %>
 
       <h3 class="govuk-heading-s">Reason</h3>
-      <p class="govuk-body">
-        <%= @validation_request["condition"]["reason"] %>
-      </p>
+      <%= render(FormattedContentComponent.new(text: @validation_request["condition"]["reason"])) %>
 
       <%= render 'form', request: @validation_request %>
     </div>

--- a/app/views/pre_commencement_condition_validation_requests/show.html.erb
+++ b/app/views/pre_commencement_condition_validation_requests/show.html.erb
@@ -12,14 +12,10 @@
       <% else %>
         <h1 class="govuk-heading-l">Response to pre-commencement condition validation change request</h1>
         <h2 class="govuk-heading-m">Condition <%= "#{@validation_request["condition"]["title"]}" %></h2>
-        <p class="govuk-body">
-          <%= @validation_request["condition"]["text"] %>
-        </p>
+        <%= render(FormattedContentComponent.new(text: @validation_request["condition"]["text"])) %>
 
         <h3 class="govuk-heading-s">Reason</h3>
-        <p class="govuk-body">
-          <%= @validation_request["condition"]["reason"] %>
-        </p>
+        <%= render(FormattedContentComponent.new(text: @validation_request["condition"]["reason"])) %>
 
         <% if @validation_request["approved"] == false %>
           <strong class="govuk-tag govuk-tag--red">


### PR DESCRIPTION
Carriage returns weren't showing in condition text and reasoning, but as a big block of text making it hard to read