### PR TITLE
Add .gitattributes file to ensure correct line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+* text=auto
+*.sh text eol=lf
+bin/* text eol=lf


### PR DESCRIPTION
When running docker-compose on Windows the docker-entrypoint.sh file must have UNIX-style line endings.