### PR TITLE
Accept a planning application reference in URLs

### DIFF
--- a/app/components/consultation_status_component.rb
+++ b/app/components/consultation_status_component.rb
@@ -67,6 +67,6 @@ class ConsultationStatusComponent < ViewComponent::Base
   end
 
   def decision_notice_link
-    "#{Rails.configuration.api_protocol}://#{Current.local_authority}.#{Rails.configuration.api_host}/public/planning_applications/#{planning_application["id"]}/decision_notice"
+    "#{Rails.configuration.api_protocol}://#{Current.local_authority}.#{Rails.configuration.api_host}/public/planning_applications/#{planning_application["reference"]}/decision_notice"
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -21,4 +21,9 @@ class ApplicationController < ActionController::Base
   def set_header_link
     @header_link = validation_requests_path(planning_application_id: params["planning_application_id"], change_access_id: params["change_access_id"])
   end
+
+  def set_planning_application
+    reference = params[:planning_application_reference] || params[:reference] || params[:planning_application_id]
+    @planning_application = Bops::PlanningApplication.find(reference)
+  end
 end

--- a/app/controllers/land_owners_controller.rb
+++ b/app/controllers/land_owners_controller.rb
@@ -26,10 +26,6 @@ class LandOwnersController < ApplicationController
 
   private
 
-  def set_planning_application
-    @planning_application = Bops::PlanningApplication.find(params[:planning_application_id])
-  end
-
   def set_certificate
     @ownership_certificate = OwnershipCertificate.find(params[:ownership_certificate_id])
   end

--- a/app/controllers/neighbour_responses_controller.rb
+++ b/app/controllers/neighbour_responses_controller.rb
@@ -11,7 +11,7 @@ class NeighbourResponsesController < ApplicationController
     {tags: []}
   ].freeze
 
-  PERMITTED_PARAMS = [:stage, :move_next, :move_back, :planning_application_id,
+  PERMITTED_PARAMS = [:stage, :move_next, :move_back, :planning_application_reference,
     {neighbour_response: RESPONSE_PARAMS}].freeze
 
   def start
@@ -27,7 +27,7 @@ class NeighbourResponsesController < ApplicationController
     respond_to do |format|
       format.html do
         if @new_response.save
-          redirect_to thank_you_planning_application_neighbour_responses_path(params[:planning_application_id])
+          redirect_to thank_you_planning_application_neighbour_responses_path(params[:planning_application_reference])
         else
           render :new
         end
@@ -52,10 +52,6 @@ class NeighbourResponsesController < ApplicationController
     neighbour_response_params.merge!(hash)
   end
 
-  def set_planning_application
-    @planning_application = Bops::PlanningApplication.find(params[:planning_application_id])
-  end
-
   def neighbour_response_params
     params.permit(PERMITTED_PARAMS)
   end
@@ -67,6 +63,6 @@ class NeighbourResponsesController < ApplicationController
   end
 
   def set_header_link
-    @header_link = planning_application_path(id: params["planning_application_id"])
+    @header_link = planning_application_path(reference: params["planning_application_reference"])
   end
 end

--- a/app/controllers/ownership_certificates_controller.rb
+++ b/app/controllers/ownership_certificates_controller.rb
@@ -62,7 +62,7 @@ class OwnershipCertificatesController < ApplicationController
     )
 
       redirect_to validation_requests_path(
-        planning_application_id: params[:planning_application_id],
+        planning_application_reference: params[:planning_application_reference],
         change_access_id: params[:change_access_id]
       ), notice: t("shared.response_updated.success")
     else
@@ -76,14 +76,10 @@ class OwnershipCertificatesController < ApplicationController
     @ownership_certificate = OwnershipCertificate.find(params[:ownership_certificate_id] || params[:id])
   end
 
-  def set_planning_application
-    @planning_application ||= Bops::PlanningApplication.find(params[:planning_application_id])
-  end
-
   def ownership_certificate_params
     params.require(:ownership_certificate)
       .permit(:know_owners, :number_of_owners, :certificate_type, :notification_of_owners, :change_access_id)
-      .to_h.merge(planning_application_id: @planning_application["id"])
+      .to_h.merge(planning_application_id: @planning_application["reference"])
   end
 
   def set_validation_request

--- a/app/controllers/planning_applications_controller.rb
+++ b/app/controllers/planning_applications_controller.rb
@@ -24,10 +24,6 @@ class PlanningApplicationsController < ApplicationController
     render plain: "Not Found", status: :not_found
   end
 
-  def set_planning_application
-    @planning_application = Bops::PlanningApplication.find(params[:id])
-  end
-
   def set_local_authority
     @local_authority = Bops::LocalAuthority.find(Current.local_authority)
   end

--- a/app/controllers/site_notices_controller.rb
+++ b/app/controllers/site_notices_controller.rb
@@ -20,8 +20,4 @@ class SiteNoticesController < ApplicationController
   def render_not_found
     render plain: "Not Found", status: :not_found
   end
-
-  def set_planning_application
-    @planning_application = Bops::PlanningApplication.find(params[:planning_application_id])
-  end
 end

--- a/app/controllers/validation_requests_controller.rb
+++ b/app/controllers/validation_requests_controller.rb
@@ -14,11 +14,8 @@ class ValidationRequestsController < ApplicationController
   private
 
   def set_validation_requests
-    @validation_requests = Bops::ValidationRequest.find_all(params[:planning_application_id], params[:change_access_id])
-  end
-
-  def set_planning_application
-    @planning_application = Bops::PlanningApplication.find(params[:planning_application_id])
+    planning_application_reference = params[:planning_application_reference] || params[:planning_application_id]
+    @validation_requests = Bops::ValidationRequest.find_all(planning_application_reference, params[:change_access_id])
   end
 
   def set_local_authority
@@ -26,8 +23,9 @@ class ValidationRequestsController < ApplicationController
   end
 
   def set_validation_request
+    planning_application_reference = params[:planning_application_reference] || params[:planning_application_id]
     @validation_request = validation_request_model_klass.find(
-      params[:id], params[:planning_application_id], params[:change_access_id]
+      params[:id], planning_application_reference, params[:change_access_id]
     )
   end
 

--- a/app/models/neighbour_response.rb
+++ b/app/models/neighbour_response.rb
@@ -24,7 +24,7 @@ class NeighbourResponse
   attribute :move_next
   attribute :move_back
   attribute :final_check
-  attribute :planning_application_id, :integer
+  attribute :planning_application_reference, :integer
 
   STAGES = %w[about_you thoughts response check].freeze
 
@@ -61,7 +61,7 @@ class NeighbourResponse
     )
 
     if Bops::NeighbourResponse.create(
-      params[:planning_application_id],
+      params[:planning_application_reference],
       data: response_data
     )
       true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,7 +18,7 @@ Rails.application.routes.draw do
     resources :time_extension_validation_requests
   end
 
-  resources :planning_applications, only: %i[show] do
+  resources :planning_applications, param: :reference, only: %i[show] do
     resource :site_notices, only: %i[] do
       get :download
     end

--- a/spec/fixtures/test_planning_application.json
+++ b/spec/fixtures/test_planning_application.json
@@ -15,7 +15,7 @@
   "invalidated_at": "2021-04-23T10:15:52.855Z",
   "in_assessment_at": null,
   "payment_reference": "PAY1",
-  "reference": "22-00100-LDCP",
+  "reference": "22-00128-LDCP",
   "returned_at": null,
   "started_at": null,
   "status": "invalidated",

--- a/spec/fixtures/test_private_planning_application.json
+++ b/spec/fixtures/test_private_planning_application.json
@@ -15,7 +15,7 @@
   "invalidated_at": "2021-04-23T10:15:52.855Z",
   "in_assessment_at": null,
   "payment_reference": "PAY1",
-  "reference": "22-00100-LDCP",
+  "reference": "22-00129-LDCP",
   "returned_at": null,
   "started_at": null,
   "status": "invalidated",

--- a/spec/support/api_spec_helper.rb
+++ b/spec/support/api_spec_helper.rb
@@ -17,16 +17,20 @@ module ApiSpecHelper
     stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28")
       .with(headers:)
       .to_return(status: 200, body: file_fixture("test_planning_application.json").read, headers: {})
+
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP")
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("test_planning_application.json").read, headers: {})
   end
 
   def stub_successful_get_private_planning_application
-    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/29")
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00129-LDCP")
       .with(headers:)
       .to_return(status: 200, body: file_fixture("test_private_planning_application.json").read, headers: {})
   end
 
   def stub_unsuccessful_get_planning_application
-    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/100")
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-99999-LDCP")
       .with(headers:)
       .to_return(status: 404, body: '{"message": "Not found"}', headers: {})
   end
@@ -41,16 +45,22 @@ module ApiSpecHelper
     stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
       .with(headers:)
       .to_return(status: 200, body: file_fixture("test_change_request_index.json").read, headers: {})
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP/validation_requests?change_access_id=345443543")
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("test_change_request_index.json").read, headers: {})
   end
 
   def stub_rejected_patch_with_reason
-    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP/validation_requests?change_access_id=345443543")
       .with(headers:)
       .to_return(status: 200, body: file_fixture("rejected_request.json").read, headers: {})
   end
 
   def stub_cancelled_change_requests
     stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
+      .with(headers:)
+      .to_return(status: 200, body: file_fixture("cancelled_validation_requests.json").read, headers: {})
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP/validation_requests?change_access_id=345443543")
       .with(headers:)
       .to_return(status: 200, body: file_fixture("cancelled_validation_requests.json").read, headers: {})
   end
@@ -81,7 +91,7 @@ module ApiSpecHelper
       response_body = parsed_body.to_json
     end
 
-    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28")
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP")
       .with(headers:)
       .to_return(status: 200, body: response_body, headers: {})
   end

--- a/spec/system/consultation_status_spec.rb
+++ b/spec/system/consultation_status_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe "Planning applications", type: :system do
           }
       )
 
-      visit "/planning_applications/28"
+      visit "/planning_applications/22-00128-LDCP"
     end
 
     it "shows that comments will no longer be accepted" do
@@ -51,7 +51,7 @@ RSpec.describe "Planning applications", type: :system do
             }
         )
 
-        visit "/planning_applications/28"
+        visit "/planning_applications/22-00128-LDCP"
       end
 
       it "shows the granted status and provides a link to the decision notice" do
@@ -76,7 +76,7 @@ RSpec.describe "Planning applications", type: :system do
             }
         )
 
-        visit "/planning_applications/28"
+        visit "/planning_applications/22-00128-LDCP"
       end
 
       it "shows the granted (not required) status and provides a link to the decision notice" do
@@ -89,7 +89,7 @@ RSpec.describe "Planning applications", type: :system do
 
           expect(page).to have_link(
             "View decision notice",
-            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/28/decision_notice"
+            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/22-00128-LDCP/decision_notice"
           )
         end
       end
@@ -106,7 +106,7 @@ RSpec.describe "Planning applications", type: :system do
             }
         )
 
-        visit "/planning_applications/28"
+        visit "/planning_applications/22-00128-LDCP"
       end
 
       it "shows the refused status and provides a link to the decision notice" do
@@ -119,7 +119,7 @@ RSpec.describe "Planning applications", type: :system do
 
           expect(page).to have_link(
             "View decision notice",
-            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/28/decision_notice"
+            href: "#{Rails.configuration.api_protocol}://default.#{Rails.configuration.api_host}/public/planning_applications/22-00128-LDCP/decision_notice"
           )
         end
       end
@@ -140,7 +140,7 @@ RSpec.describe "Planning applications", type: :system do
         )
 
         travel_to(DateTime.new(2023, 11, 4)) do
-          visit "/planning_applications/28"
+          visit "/planning_applications/22-00128-LDCP"
         end
       end
 
@@ -170,7 +170,7 @@ RSpec.describe "Planning applications", type: :system do
         )
 
         travel_to(DateTime.new(2023, 11, 24)) do
-          visit "/planning_applications/28"
+          visit "/planning_applications/22-00128-LDCP"
         end
       end
 

--- a/spec/system/landing_page_spec.rb
+++ b/spec/system/landing_page_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe "landing page", type: :system do
   end
 
   it "renders the application reference" do
-    expect(page).to have_content("Application number: 22-00100-LDCP")
+    expect(page).to have_content("Application number: 22-00128-LDCP")
   end
 
   context "within phase-banner" do

--- a/spec/system/neighbour_submits_comment_spec.rb
+++ b/spec/system/neighbour_submits_comment_spec.rb
@@ -28,7 +28,7 @@ RSpec.describe "Planning applications", js: true, type: :system do
       tags: %w[access other]
     )
 
-    visit "/planning_applications/28"
+    visit "/planning_applications/22-00128-LDCP"
 
     click_link "Submit a comment"
 
@@ -102,7 +102,7 @@ RSpec.describe "Planning applications", js: true, type: :system do
       tags: %w[noise other]
     )
 
-    visit "/planning_applications/28"
+    visit "/planning_applications/22-00128-LDCP"
 
     click_link "Submit a comment"
 
@@ -193,7 +193,7 @@ RSpec.describe "Planning applications", js: true, type: :system do
       tags: ["acess"]
     )
 
-    visit "/planning_applications/28"
+    visit "/planning_applications/22-00128-LDCP"
 
     click_link "this link"
 

--- a/spec/system/planning_applications_spec.rb
+++ b/spec/system/planning_applications_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe "Planning applications", type: :system do
     stub_successful_get_planning_application
     stub_successful_get_local_authority
 
-    visit "/planning_applications/28"
+    visit "/planning_applications/22-00128-LDCP"
 
     expect(page).to have_content("11 Mel Gardens, Southwark, SE16 3RQ")
     expect(page).to have_content("Add a chimney stack")
@@ -43,7 +43,7 @@ RSpec.describe "Planning applications", type: :system do
   it "shows 404 if not found" do
     stub_unsuccessful_get_planning_application
 
-    visit "/planning_applications/100"
+    visit "/planning_applications/22-99999-LDCP"
 
     expect(page).to have_content("Not Found")
   end
@@ -52,7 +52,7 @@ RSpec.describe "Planning applications", type: :system do
     stub_successful_get_private_planning_application
     stub_successful_get_local_authority
 
-    visit "/planning_applications/29"
+    visit "/planning_applications/22-00129-LDCP"
 
     expect(page).to have_content("Not Found")
   end

--- a/spec/system/site_notices_spec.rb
+++ b/spec/system/site_notices_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Site notices", type: :system do
   it "allows the user to see a planning application if it's public" do
     stub_successful_get_planning_application
 
-    visit "/planning_applications/28/site_notices/download"
+    visit "/planning_applications/22-00128-LDCP/site_notices/download"
 
     expect(page).to have_content("Download your site notice")
     expect(page).to have_content("11 Mel Gardens, Southwark, SE16 3RQ")
@@ -22,7 +22,7 @@ RSpec.describe "Site notices", type: :system do
   it "shows 404 if not found" do
     stub_unsuccessful_get_planning_application
 
-    visit "/planning_applications/100/site_notices/download"
+    visit "/planning_applications/22-99999-LDCP/site_notices/download"
 
     expect(page).to have_content("Not Found")
   end
@@ -31,7 +31,7 @@ RSpec.describe "Site notices", type: :system do
     stub_successful_get_private_planning_application
     stub_successful_get_local_authority
 
-    visit "/planning_applications/29/site_notices/download"
+    visit "/planning_applications/22-00129-LDCP/site_notices/download"
 
     expect(page).to have_content("Not Found")
   end

--- a/spec/system/validation_request_spec.rb
+++ b/spec/system/validation_request_spec.rb
@@ -24,6 +24,8 @@ RSpec.describe "Change requests", type: :system do
   it "forbids the user from accessing change requests for a different application" do
     stub_request(:get, "https://default.bops.test/api/v1/planning_applications/28/validation_requests?change_access_id=345443543")
       .to_return(status: 401, body: "{}")
+    stub_request(:get, "https://default.bops.test/api/v1/planning_applications/22-00128-LDCP/validation_requests?change_access_id=345443543")
+      .to_return(status: 401, body: "{}")
     stub_successful_get_planning_application
 
     visit "/validation_requests?planning_application_id=28&change_access_id=345443543"
@@ -39,7 +41,7 @@ RSpec.describe "Change requests", type: :system do
 
     expect(page).to have_content("11 Mel Gardens, London, SE16 3RQ")
     expect(page).to have_content("Date received: 23 April 2021")
-    expect(page).to have_content("Application number: 22-00100-LDCP")
+    expect(page).to have_content("Application number: 22-00128-LDCP")
   end
 
   it "displays the description of the change request on the change request page" do


### PR DESCRIPTION
Match BOPS behaviour by accepting references instead of application IDs.

Should still accept both. Doesn't redirect to the reference if an ID is provided.
