### PR TITLE
Remove bundle-audit check

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,11 +12,6 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  bundle-audit:
-    uses: ./.github/workflows/linters.yml
-    with:
-      bundler-audit: true
-
   brakeman:
     uses: ./.github/workflows/linters.yml
     with:

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -4,9 +4,6 @@ name: Verify
 on:
   workflow_call:
     inputs:
-      bundler-audit:
-        type: boolean
-        default: false
       brakeman:
         type: boolean
         default: false
@@ -42,11 +39,6 @@ jobs:
         with:
           node-version-file: .node-version
       - run: yarn install
-
-      - name: Check bundle for known CVEs
-        if: ${{ inputs.bundler-audit == true }}
-        run: |
-          bundle exec bundler-audit
 
       - name: Analyse code for vulnerabilities
         if: ${{ inputs.brakeman == true }}


### PR DESCRIPTION
We already have dependabot monitoring for security updates. All bundle-audit achieves is blocking unrelated PRs (including a potential chicken-and-egg scenario if there are two security PRs at once). Cf unboxed/bops#1239.